### PR TITLE
feat: implement rate-limit handling logic 

### DIFF
--- a/src/hiero_analytics/data_sources/github_client.py
+++ b/src/hiero_analytics/data_sources/github_client.py
@@ -1,9 +1,8 @@
 """
 Low-level GitHub HTTP client.
 
-Handles authentication, connection reuse, retries,
-GraphQL rate-limit awareness, and request execution
-for both REST and GraphQL GitHub API calls.
+Handles authentication, connection reuse, retries, and request execution
+for both REST and GraphQL API calls.
 """
 
 from __future__ import annotations
@@ -11,8 +10,7 @@ from __future__ import annotations
 import logging
 import time
 from collections.abc import Mapping
-from datetime import UTC, datetime
-from typing import Any, TypedDict
+from typing import Any
 
 import requests
 
@@ -22,43 +20,25 @@ from hiero_analytics.config.github import (
     HTTP_TIMEOUT_SECONDS,
     REQUEST_DELAY_SECONDS,
 )
+from .rate_limit import (
+    Action,
+    JSON,
+    RateLimitDecision,
+    RateLimitPolicy,
+    RateLimitSnapshot,
+)
 
 logger = logging.getLogger(__name__)
 
 MAX_RETRIES = 3
-
-
-# --------------------------------------------------------
-# TYPES
-# --------------------------------------------------------
-
-JSON = dict[str, Any]
-
-
-class GraphQLRateLimit(TypedDict, total=False):
-    """
-    GraphQL returns rate limit information.
-        cost: cost of the query
-        remaining: available api requests 
-        limit: maximum api requests
-        resetAt: limit resets each hour, notifies you when that is
-
-    """
-    cost: int
-    remaining: int
-    limit: int
-    resetAt: str
-
+MAX_GRAPHQL_FRESH_RETRIES = 2
 
 # --------------------------------------------------------
 # HEADERS
 # --------------------------------------------------------
 
 def github_headers() -> dict[str, str]:
-    """
-    Build HTTP headers used for GitHub API requests.
-    This is required for github to accept the query.
-    """
+    """Build HTTP headers required for GitHub API requests."""
     headers: dict[str, str] = {
         "User-Agent": "hiero-analytics",
         "Accept": "application/vnd.github+json",
@@ -71,12 +51,10 @@ def github_headers() -> dict[str, str]:
         return headers
 
     logger.info(
-        "Using GITHUB_TOKEN for authenticated requests. API allows up to 5000 requests per hour."
+        "Using GITHUB_TOKEN for authenticated requests. "
+        "API allows up to 5000 requests per hour."
     )
-
-    # Pass the Github Token for higher rate limits
     headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
-
     return headers
 
 
@@ -88,17 +66,14 @@ class GitHubClient:
     """HTTP client for interacting with the GitHub API."""
 
     def __init__(self) -> None:
-        """
-        Initialize the client with a persistent HTTP session and
-        authentication headers.
-        """
-        # Reusable HTTP session with default headers for authentication and content type
         self.session: requests.Session = requests.Session()
         self.session.headers.update(github_headers())
 
-        # usage counters to keep track of API usage 
+        # Rate-limit policy: reads signals, returns decisions.
+        self._policy = RateLimitPolicy()
+
+        # usage counters to keep track of API usage
         self.requests_made: int = 0
-        # this is the graphQL counter which has uses variable costs 
         self.cost_used: int = 0
 
     # --------------------------------------------------------
@@ -106,238 +81,138 @@ class GitHubClient:
     # --------------------------------------------------------
 
     def log_usage(self) -> None:
-        """Log API usage statistics."""
+        """Log cumulative API usage statistics."""
         logger.info(
             "GitHub API usage: %d requests, %d GraphQL points used",
             self.requests_made,
             self.cost_used,
         )
 
-    # --------------------------------------------------------
-    # RATE LIMIT HANDLING
-    # --------------------------------------------------------
+    def _apply_decision(self, decision: RateLimitDecision) -> Action:
+        """Apply policy decision side effects and return the action."""
+        if decision.sleep_seconds > 0:
+            time.sleep(decision.sleep_seconds)
+        return decision.action
 
-    def _handle_graphql_rate(self, data: JSON) -> None:
-        """Handle GraphQL rate-limit reporting and throttling."""
-        rate: GraphQLRateLimit | None = (data.get("data") or {}).get("rateLimit")
-
-        if not rate:
-            return
-
-        remaining = rate.get("remaining")
-        cost = rate.get("cost")
-        limit = rate.get("limit")
-        reset_at = rate.get("resetAt")
-
-        logger.debug(
-            "GraphQL cost=%s remaining=%s/%s",
-            cost,
-            remaining,
-            limit,
-        )
-
-        if reset_at:
-
-            reset_time = datetime.fromisoformat(reset_at.replace("Z", "+00:00"))
-            now = datetime.now(UTC)
-
-            seconds_until_reset = int((reset_time - now).total_seconds())
-
-            logger.debug(
-                "GraphQL rate limit resets at %s (%ds)",
-                reset_time.isoformat(),
-                max(seconds_until_reset, 0),
-            )
-
-        if remaining is not None and remaining < 50:
-
-            logger.warning(
-                "GraphQL budget low (%s remaining). Pausing briefly.",
-                remaining,
-            )
-
-            time.sleep(5)
-
-    # --------------------------------------------------------
-    # ERROR HANDLING
-    # --------------------------------------------------------
-
-    def _handle_graphql_errors(
+    def _record_usage(
         self,
         data: JSON,
-        method: str,
-        url: str,
-        kwargs: Mapping[str, Any],
-    ) -> JSON | None:
-        """Detect GraphQL errors and retry if rate-limited."""
-        errors = data.get("errors")
-
-        if not errors:
+        *,
+        is_graphql: bool,
+    ) -> RateLimitSnapshot | None:
+        """Extract rate-limit info from response and update usage counters."""
+        self.requests_made += 1
+        if not is_graphql:
             return None
 
-        for err in errors:
-
-            if err.get("type") == "RATE_LIMIT":
-
-                logger.warning("GraphQL rate limit exceeded.")
-
-                rate: GraphQLRateLimit | None = (data.get("data") or {}).get("rateLimit")
-
-                if rate and rate.get("resetAt"):
-
-                    reset_time = datetime.fromisoformat(
-                        rate["resetAt"].replace("Z", "+00:00")
-                    )
-
-                    now = datetime.now(UTC)
-                    wait_seconds = int((reset_time - now).total_seconds())
-
-                    wait_seconds = max(wait_seconds, 60)
-
-                    logger.warning(
-                        "Sleeping %ds until rate limit reset at %s",
-                        wait_seconds,
-                        reset_time.isoformat(),
-                    )
-
-                    time.sleep(wait_seconds)
-
-                    return self._request(method, url, **kwargs)
-
-                logger.warning("Sleeping 300s before retrying request")
-
-                time.sleep(300)
-
-                return self._request(method, url, **kwargs)
-
-        raise RuntimeError(f"GitHub GraphQL error: {data}")
+        snapshot = RateLimitSnapshot.from_graphql_payload(data)
+        if snapshot and snapshot.cost is not None:
+            self.cost_used += snapshot.cost
+        return snapshot
 
     # --------------------------------------------------------
     # REQUEST EXECUTION
     # --------------------------------------------------------
 
-    def _request(
+    def _execute_http_with_retries(
         self,
         method: str,
         url: str,
         **kwargs: Any,
-    ) -> JSON:
+    ) -> requests.Response:
         """
-        Execute HTTP request with retries and rate-limit awareness for both
-        REST (via HTTP headers) and GraphQL (via response payload).
+        Handle low-level network retries and REST header-based rate limiting.
+        Returns a successful HTTP response or raises.
         """
         for attempt in range(1, MAX_RETRIES + 1):
-
             logger.debug(
-                "GitHub request → %s %s (attempt %d)",
+                "GitHub request -> %s %s (attempt %d)",
                 method,
                 url,
                 attempt,
             )
-
             start = time.time()
 
             try:
-
                 response = self.session.request(
                     method,
                     url,
                     timeout=HTTP_TIMEOUT_SECONDS,
                     **kwargs,
                 )
-
             except requests.RequestException as exc:
-
                 if attempt == MAX_RETRIES:
                     logger.error(
                         "GitHub request failed after %d attempts",
                         MAX_RETRIES,
                     )
                     raise
-
                 logger.warning(
                     "Request error (%s). Retrying attempt %d...",
                     exc,
                     attempt + 1,
                 )
-
-                time.sleep(2**attempt)
+                time.sleep(2 ** attempt)
                 continue
 
-            elapsed = time.time() - start
+            logger.debug("GitHub response <- %.2fs", time.time() - start)
 
-            logger.debug("GitHub response ← %.2fs", elapsed)
+            # Check REST headers for all endpoints, including GraphQL.
+            snapshot = RateLimitSnapshot.from_rest_headers(response.headers)
+            if snapshot:
+                rest_decision = self._policy.check_rest_response(
+                    snapshot,
+                    status_code=response.status_code,
+                    is_ok=response.ok,
+                    attempt=attempt,
+                    max_retries=MAX_RETRIES,
+                )
+                action = self._apply_decision(rest_decision)
+                if action == Action.DELAY_THEN_RETRY_LOOP:
+                    continue
 
-            # --------------------------------------------------------
-            # REST rate-limit handling (non-GraphQL responses)
-            # --------------------------------------------------------
-            is_graphql = url.endswith("/graphql")
-            if not is_graphql:
-                remaining_header = response.headers.get("X-RateLimit-Remaining")
-                reset_header = response.headers.get("X-RateLimit-Reset")
-                if remaining_header is not None and reset_header is not None:
-                    try:
-                        remaining = int(remaining_header)
-                        reset_epoch = int(reset_header)
-                    except (TypeError, ValueError):
-                        remaining = None
-                        reset_epoch = None
-                    if remaining == 0 and reset_epoch is not None:
-                        # Compute how long to wait until the rate limit resets.
-                        sleep_seconds = max(0, reset_epoch - int(time.time()))
-                        if response.status_code == 403 and attempt < MAX_RETRIES:
-                            logger.warning(
-                                "GitHub REST rate limit reached (403). "
-                                "Sleeping for %ds before retrying attempt %d...",
-                                sleep_seconds,
-                                attempt + 1,
-                            )
-                            if sleep_seconds > 0:
-                                time.sleep(sleep_seconds)
-                            continue
-                        if response.ok and sleep_seconds > 0:
-                            # Successful response but no remaining budget; delay
-                            # to avoid immediate rate-limit errors on subsequent calls.
-                            logger.warning(
-                                "GitHub REST rate limit exhausted. "
-                                "Sleeping for %ds before returning response...",
-                                sleep_seconds,
-                            )
-                            time.sleep(sleep_seconds)
-            # For GraphQL and non-rate-limited REST responses, propagate HTTP errors.
-            
             response.raise_for_status()
+            return response
 
+        raise RuntimeError("Unreachable request state")
+
+
+    def _request(self, method: str, url: str, **kwargs: Any) -> JSON:
+        """
+        Execute request and apply GraphQL-specific retry policy.
+        """
+        is_graphql = url.endswith("/graphql")
+
+        for _fresh_retry_count in range(MAX_GRAPHQL_FRESH_RETRIES + 1):
+            response = self._execute_http_with_retries(method, url, **kwargs)
             data: JSON = response.json()
 
-            # update counters
-            self.requests_made += 1
+            # Keep usage accounting for both REST and GraphQL.
+            graphql_snapshot = self._record_usage(data, is_graphql=is_graphql)
 
-            # --------------------------------------------------------
-            # GraphQL-specific rate-limit accounting
-            # --------------------------------------------------------
-            rate: GraphQLRateLimit | None = (data.get("data") or {}).get("rateLimit")
-            if rate:
-                self.cost_used += rate.get("cost", 0)
+            if not is_graphql:
+                if REQUEST_DELAY_SECONDS > 0:
+                    time.sleep(REQUEST_DELAY_SECONDS)
+                return data
 
-            retry = self._handle_graphql_errors(
-                data,
-                method,
-                url,
-                kwargs,
-            )
+            error_decision = self._policy.check_graphql_errors(data, graphql_snapshot)
+            action = self._apply_decision(error_decision)
 
-            if retry is not None:
-                return retry
+            if action == Action.DELAY_THEN_RETRY_FRESH:
+                continue
 
-            self._handle_graphql_rate(data)
+            if graphql_snapshot:
+                budget_decision = self._policy.check_graphql_budget(graphql_snapshot)
+                self._apply_decision(budget_decision)
 
             if REQUEST_DELAY_SECONDS > 0:
                 time.sleep(REQUEST_DELAY_SECONDS)
 
             return data
 
-        raise RuntimeError("Unreachable request state")
+        raise RuntimeError(
+            "GraphQL fresh retry limit exceeded after RATE_LIMIT responses"
+        )
 
     # --------------------------------------------------------
     # PUBLIC API
@@ -355,11 +230,7 @@ class GitHubClient:
         """
         return self._request("GET", url, **kwargs)
 
-    def graphql(
-        self,
-        query: str,
-        variables: Mapping[str, Any],
-    ) -> JSON:
+    def graphql(self, query: str, variables: Mapping[str, Any]) -> JSON:
         """
         Execute a GraphQL query against the GitHub API.
 
@@ -370,13 +241,5 @@ class GitHubClient:
         Returns:
             Parsed JSON response
         """
-        payload: JSON = {
-            "query": query,
-            "variables": dict(variables),
-        }
-
-        return self._request(
-            "POST",
-            f"{BASE_URL}/graphql",
-            json=payload,
-        )
+        payload: JSON = {"query": query, "variables": dict(variables)}
+        return self._request("POST", f"{BASE_URL}/graphql", json=payload)

--- a/src/hiero_analytics/data_sources/rate_limit.py
+++ b/src/hiero_analytics/data_sources/rate_limit.py
@@ -1,0 +1,303 @@
+"""
+GitHub API rate-limit policy.
+
+Reads rate-limit signals from REST headers and GraphQL response payloads
+and returns an Action decision.  No side effects: this module never sleeps
+or makes HTTP calls — the GitHubClient loop does that.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum, auto
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+JSON = dict[str, Any]
+
+
+# --------------------------------------------------------
+# NORMALIZED SNAPSHOT
+# --------------------------------------------------------
+
+@dataclass(frozen=True)
+class RateLimitSnapshot:
+    """
+    A single, normalized view of GitHub rate-limit state.
+
+    Built from either:
+    - REST response headers  (X-RateLimit-*)
+    - GraphQL response body  (data.rateLimit)
+
+    Having one shape regardless of protocol means policy logic
+    only has to be written once.
+    """
+
+    remaining: int | None = None    # requests / points left
+    limit: int | None = None        # total budget per window
+    cost: int | None = None         # GraphQL only: cost of this query
+    reset_at: datetime | None = None  # aware UTC datetime when budget resets
+
+    @classmethod
+    def from_rest_headers(cls, headers: Mapping[str, str]) -> RateLimitSnapshot | None:
+        """
+        Build from X-RateLimit-* HTTP response headers.
+
+        Returns None when the headers are absent (e.g. webhook endpoints
+        or GraphQL endpoints don't send them).
+        """
+        raw_remaining = headers.get("X-RateLimit-Remaining")
+        raw_reset = headers.get("X-RateLimit-Reset")
+        raw_limit = headers.get("X-RateLimit-Limit")
+
+        if raw_remaining is None and raw_reset is None:
+            return None
+
+        try:
+            remaining = int(raw_remaining) if raw_remaining is not None else None
+            reset_epoch = int(raw_reset) if raw_reset is not None else None
+            limit = int(raw_limit) if raw_limit is not None else None
+        except (TypeError, ValueError):
+            return None
+
+        reset_at = (
+            datetime.fromtimestamp(reset_epoch, tz=timezone.utc)
+            if reset_epoch is not None
+            else None
+        )
+
+        return cls(remaining=remaining, limit=limit, reset_at=reset_at)
+
+    @classmethod
+    def from_graphql_payload(cls, data: JSON) -> RateLimitSnapshot | None:
+        """
+        Build from a GraphQL response body that includes a rateLimit field.
+
+        Returns None when the query didn't request rateLimit.
+        """
+        rate = (data.get("data") or {}).get("rateLimit")
+        if not rate:
+            return None
+
+        reset_at: datetime | None = None
+        raw_reset = rate.get("resetAt")
+        if raw_reset:
+            reset_at = datetime.fromisoformat(raw_reset.replace("Z", "+00:00"))
+
+        return cls(
+            remaining=rate.get("remaining"),
+            limit=rate.get("limit"),
+            cost=rate.get("cost"),
+            reset_at=reset_at,
+        )
+
+    def seconds_until_reset(self) -> int:
+        """Seconds until the budget window resets (0 if unknown or already passed)."""
+        if self.reset_at is None:
+            return 0
+        return max(0, int((self.reset_at - datetime.now(timezone.utc)).total_seconds()))
+
+
+# --------------------------------------------------------
+# DECISION
+# --------------------------------------------------------
+
+class Action(Enum):
+    """What the GitHubClient loop should do after reading rate-limit signals."""
+
+    PROCEED = auto()
+    """No action needed — return the response normally."""
+
+    DELAY_THEN_PROCEED = auto()
+    """
+    Sleep for `sleep_seconds`, then return the current response.
+    Used when REST budget is exhausted but the response was still 200 OK.
+    """
+
+    DELAY_THEN_RETRY_LOOP = auto()
+    """
+    Sleep for `sleep_seconds`, then `continue` the retry loop.
+    Used for REST 403 rate-limit errors where we want to retry the same request.
+    """
+
+    DELAY_THEN_RETRY_FRESH = auto()
+    """
+    Sleep for `sleep_seconds`, then restart the whole request (resets retries).
+    Used for GraphQL RATE_LIMIT errors, which can occur independently of
+    the REST quota and may require waiting a full hour.
+    """
+
+
+@dataclass(frozen=True)
+class RateLimitDecision:
+    """ A decision returned by the policy after inspecting a snapshot or response.
+    The GitHubClient loop will apply the decision by sleeping and/or retrying
+    as needed.
+    """
+
+    action: Action
+    sleep_seconds: int = 0
+    reason: str = ""
+
+
+# --------------------------------------------------------
+# THRESHOLDS
+# --------------------------------------------------------
+
+# GraphQL: warn and slow down when this many points remain
+_GRAPHQL_LOW_BUDGET_THRESHOLD = 50
+_GRAPHQL_LOW_BUDGET_SLEEP = 5
+
+# GraphQL RATE_LIMIT error: wait at least this long even if reset_at is missing
+_GRAPHQL_ERROR_FALLBACK_SLEEP = 300
+# GraphQL RATE_LIMIT error: never sleep less than this even if reset_at is soon
+_GRAPHQL_ERROR_MIN_SLEEP = 60
+
+
+# --------------------------------------------------------
+# POLICY
+# --------------------------------------------------------
+
+class RateLimitPolicy:
+    """
+    Pure rate-limit decision logic.
+
+    Each method inspects a snapshot (or raw data) and returns a
+    RateLimitDecision.  No sleeping, no HTTP calls, no state mutations.
+    """
+
+    def check_rest_response(
+        self,
+        snapshot: RateLimitSnapshot,
+        *,
+        status_code: int,
+        is_ok: bool,
+        attempt: int,
+        max_retries: int,
+    ) -> RateLimitDecision:
+        """
+        Decide what to do after reading REST rate-limit headers.
+
+        Decision tree:
+        1. Budget > 0       → PROCEED  (no sleep needed)
+        2. Budget = 0 + 403 → DELAY_THEN_RETRY_LOOP  (standard retry)
+        3. Budget = 0 + 200 → DELAY_THEN_PROCEED     (courtesy sleep before return)
+        """
+        if snapshot.remaining is None:
+            return RateLimitDecision(Action.PROCEED)
+
+        logger.debug(
+            "REST rate limit: remaining=%s/%s resets in %ds",
+            snapshot.remaining,
+            snapshot.limit,
+            snapshot.seconds_until_reset(),
+        )
+
+        if snapshot.remaining > 0:
+            return RateLimitDecision(Action.PROCEED)
+
+        # Budget is zero
+        sleep_seconds = snapshot.seconds_until_reset()
+
+        if status_code == 403 and attempt < max_retries:
+            logger.warning(
+                "REST rate limit hit (403). Sleeping %ds before retry %d.",
+                sleep_seconds,
+                attempt + 1,
+            )
+            return RateLimitDecision(
+                Action.DELAY_THEN_RETRY_LOOP,
+                sleep_seconds=sleep_seconds,
+                reason="REST 403 rate-limit",
+            )
+
+        if is_ok and sleep_seconds > 0:
+            logger.warning(
+                "REST rate limit exhausted. Sleeping %ds before returning response.",
+                sleep_seconds,
+            )
+            return RateLimitDecision(
+                Action.DELAY_THEN_PROCEED,
+                sleep_seconds=sleep_seconds,
+                reason="REST budget exhausted on successful response",
+            )
+
+        return RateLimitDecision(Action.PROCEED)
+
+    def check_graphql_budget(
+        self,
+        snapshot: RateLimitSnapshot,
+    ) -> RateLimitDecision:
+        """
+        Proactive back-off when GraphQL budget is critically low.
+        Called after every successful GraphQL response.
+        """
+        if snapshot.remaining is None:
+            return RateLimitDecision(Action.PROCEED)
+
+        logger.debug(
+            "GraphQL rate limit: cost=%s remaining=%s/%s resets in %ds",
+            snapshot.cost,
+            snapshot.remaining,
+            snapshot.limit,
+            snapshot.seconds_until_reset(),
+        )
+
+        if snapshot.remaining < _GRAPHQL_LOW_BUDGET_THRESHOLD:
+            logger.warning(
+                "GraphQL budget low (%s remaining). Pausing %ds.",
+                snapshot.remaining,
+                _GRAPHQL_LOW_BUDGET_SLEEP,
+            )
+            return RateLimitDecision(
+                Action.DELAY_THEN_PROCEED,
+                sleep_seconds=_GRAPHQL_LOW_BUDGET_SLEEP,
+                reason=f"GraphQL budget low ({snapshot.remaining} remaining)",
+            )
+
+        return RateLimitDecision(Action.PROCEED)
+
+    def check_graphql_errors(
+        self,
+        data: JSON,
+        snapshot: RateLimitSnapshot | None,
+    ) -> RateLimitDecision:
+        """
+        Inspect GraphQL errors list.
+
+        - RATE_LIMIT type   → DELAY_THEN_RETRY_FRESH (sleep until reset, retry fresh)
+        - Any other error   → raises RuntimeError immediately (not retriable)
+        - No errors         → PROCEED
+        """
+        errors = data.get("errors")
+        if not errors:
+            return RateLimitDecision(Action.PROCEED)
+
+        for err in errors:
+            if err.get("type") == "RATE_LIMIT":
+                logger.warning("GraphQL RATE_LIMIT error received.")
+
+                sleep_seconds = _GRAPHQL_ERROR_FALLBACK_SLEEP
+                if snapshot and snapshot.reset_at:
+                    sleep_seconds = max(
+                        snapshot.seconds_until_reset(),
+                        _GRAPHQL_ERROR_MIN_SLEEP,
+                    )
+
+                logger.warning(
+                    "Sleeping %ds before retrying GraphQL request.",
+                    sleep_seconds,
+                )
+                return RateLimitDecision(
+                    Action.DELAY_THEN_RETRY_FRESH,
+                    sleep_seconds=sleep_seconds,
+                    reason="GraphQL RATE_LIMIT error",
+                )
+
+        # Non-rate-limit GraphQL errors are programming errors or server bugs.
+        # Raise immediately.
+        raise RuntimeError(f"GitHub GraphQL error: {data}")

--- a/tests/data_sources/test_github_client.py
+++ b/tests/data_sources/test_github_client.py
@@ -134,3 +134,34 @@ def test_graphql_request(monkeypatch):
 
     assert kwargs["json"]["query"] == query
     assert kwargs["json"]["variables"] == variables
+
+
+def test_graphql_fresh_retry_limit_exceeded(monkeypatch, mock_sleep):
+
+    rate_limited = Mock()
+    rate_limited.raise_for_status = Mock()
+    rate_limited.headers = {}
+    rate_limited.status_code = 200
+    rate_limited.ok = True
+    rate_limited.json.return_value = {
+        "data": {
+            "rateLimit": {
+                "remaining": 0,
+                "limit": 5000,
+                "cost": 1,
+                "resetAt": "2099-01-01T00:00:00Z",
+            }
+        },
+        "errors": [{"type": "RATE_LIMIT"}],
+    }
+
+    client = github_client.GitHubClient()
+
+    monkeypatch.setattr(
+        client.session,
+        "request",
+        Mock(return_value=rate_limited),
+    )
+
+    with pytest.raises(RuntimeError, match="GraphQL fresh retry limit exceeded"):
+        client.graphql("query { viewer { login } }", {})


### PR DESCRIPTION
**Description:**
This pull request refactors the GitHub API client to introduce a more robust, modular, and testable approach to rate-limit handling for both REST and GraphQL endpoints. The main change is the extraction of all rate-limit logic into a new `rate_limit.py` policy module, and the simplification of the `GitHubClient` class to delegate all rate-limit decisions to this policy. 

The `GitHubClient` now uses this policy for all rate-limit handling, making decisions based on the policy's output and applying any required delays or retries in its request loop.

Key changes include:

**Rate-limit policy extraction and normalization**

**Simplification and cleanup in `GitHubClient`**

**Related issue(s):**
Fixes #36 

- [ ] Documented

- [ ] Tested