### PR TITLE
fix: trigger maintainer pipeline

### DIFF
--- a/.github/workflows/update-analytics.yml
+++ b/.github/workflows/update-analytics.yml
@@ -56,6 +56,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run python -m hiero_analytics.run_contributor_profiles_repo
 
+      - name: Run maintainer analytics
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uv run python -m hiero_analytics.run_maintainer_pipeline_org
+
       - name: Check for changes
         id: check_changes
         run: |


### PR DESCRIPTION
issue: #79 

### Description
This PR updates the existing GitHub Actions workflow to include execution of the newly added maintainer analytics pipeline.

A new step has been added to .github/workflows/update-analytics.yml to trigger:

```src/hiero_analytics/run_maintainer_pipeline_org.py```

The implementation follows the same syntax and structure as the existing analytics steps, ensuring consistency across the workflow.

### Changes Made: 
- Added a new step "Run maintainer analytics" in:
```.github/workflows/update-analytics.yml```
- Configured the step to execute:
``` uv run src/hiero_analytics/run_maintainer_pipeline_org.py```
- Maintained consistency with existing workflow steps (naming, structure, execution pattern)

### Impact: 
- Ensures the maintainer analytics pipeline runs automatically as part of the daily scheduled workflow
- Keeps all analytics pipelines centralized under a single workflow
- Requires no manual intervention to update maintainer analytics data

### Testing: 
- Verified workflow syntax aligns with existing steps
- Confirmed correct script path and execution command
- No breaking changes to existing analytics jobs
