### PR TITLE
feat: include issue creation activity in maintainer pipeline (#131)

### DIFF
--- a/docs/maintainer_pipeline_flow.md
+++ b/docs/maintainer_pipeline_flow.md
@@ -7,7 +7,7 @@ The maintainer pipeline estimates **active governance participation** across the
 It does this by combining:
 
 - the **governance source of truth** for repository roles
-- the **observed GitHub pull request activity** of contributors
+- the **observed GitHub issue and pull request activity** of contributors
 
 The final production outputs are charts and CSVs that show how many unique active contributors were observed as:
 
@@ -25,7 +25,7 @@ The maintainer pipeline runs in this order:
 1. Fetch the Hiero governance configuration.
 2. Build a repo-level lookup of contributor roles from governance.
 3. Fetch contributor activity from GitHub across the organization.
-4. Keep only PR lifecycle signals relevant to this pipeline.
+4. Keep only issue creation and PR lifecycle signals relevant to this pipeline.
 5. Assign each activity record a repo-scoped governance role.
 6. Aggregate unique contributors by year and by repository.
 7. Save CSV outputs and render charts.
@@ -58,17 +58,19 @@ The governance file provides:
 
 Contributor activity is fetched from the GitHub GraphQL API using:
 
-- `src/hiero_analytics/data_sources/github_queries.py`
+- `src/hiero_analytics/data_sources/queries/`
 - `src/hiero_analytics/data_sources/github_ingest.py`
 
-The maintainer pipeline uses PR lifecycle data only:
+The maintainer pipeline uses issue creation and PR lifecycle data:
 
+- issue author
 - PR author
 - PR reviewer
 - PR merger
 
 Specifically, the current pipeline emits these activity types:
 
+- `authored_issue`
 - `authored_pull_request`
 - `reviewed_pull_request`
 - `merged_pull_request`
@@ -116,7 +118,7 @@ By default:
 
 Important note:
 
-- The current maintainer pipeline still works correctly because the classification step explicitly filters to the three PR lifecycle types listed above.
+- The current maintainer pipeline still works correctly because the classification step explicitly filters to the issue creation and PR lifecycle types listed above.
 
 ## Step 1: Build Governance Role Lookup
 
@@ -185,10 +187,11 @@ That function:
 
 ### Repo-Level Fetch
 
-For each repository, the pipeline fetches pull requests ordered by `UPDATED_AT DESC`.
+For each repository, the pipeline fetches pull requests ordered by `UPDATED_AT DESC` and issues ordered by `CREATED_AT DESC`.
 
-For each PR, it emits contributor activity records for:
+For each issue or PR, it emits contributor activity records for:
 
+- the issue author
 - the PR author
 - each reviewer
 - the user who merged the PR
@@ -199,11 +202,12 @@ Each emitted record is normalized into a `ContributorActivityRecord`.
 
 The repo fetcher applies the `183`-day cutoff at record creation time:
 
+- issue authors are kept only if `createdAt >= cutoff`
 - PR authors are kept only if `createdAt >= cutoff`
 - reviewers are kept only if `submittedAt >= cutoff`
 - mergers are kept only if `mergedAt >= cutoff`
 
-It also stops pagination early once the oldest PR on a page has `updatedAt < cutoff`.
+Issue pagination stops early once a page contains issues created before the cutoff.
 
 ## Step 3: Convert Activity to Role-Labeled Events
 
@@ -214,6 +218,7 @@ This transformation lives in:
 For each activity record:
 
 1. Keep only these activity types:
+   - `authored_issue`
    - `authored_pull_request`
    - `reviewed_pull_request`
    - `merged_pull_request`
@@ -385,13 +390,13 @@ The governance counts answer:
 
 The activity pipeline answers:
 
-- who both holds the role and was recently active through PR lifecycle events
+- who both holds the role and was recently active through issue creation or PR lifecycle events
 
 So the governance count is usually larger, especially for:
 
 - committers
 - repositories with many configured role holders
-- repos where not all role holders authored, reviewed, or merged PRs in the lookback window
+- repos where not all role holders opened issues or authored, reviewed, or merged PRs in the lookback window
 
 ## Why This Methodology Was Chosen
 
@@ -439,7 +444,7 @@ That order shows:
 - `src/hiero_analytics/analysis/maintainer_pipeline.py`
 - `src/hiero_analytics/data_sources/governance_config.py`
 - `src/hiero_analytics/data_sources/github_ingest.py`
-- `src/hiero_analytics/data_sources/github_queries.py`
+- `src/hiero_analytics/data_sources/queries/`
 - `src/hiero_analytics/data_sources/cache.py`
 - `src/hiero_analytics/export/save.py`
 - `src/hiero_analytics/plotting/bars.py`

--- a/src/hiero_analytics/analysis/label_analysis.py
+++ b/src/hiero_analytics/analysis/label_analysis.py
@@ -1,3 +1,4 @@
+"""Module for analyzing and counting repository labels."""
 from __future__ import annotations
 
 from hiero_analytics.data_sources.models import IssueRecord
@@ -10,8 +11,7 @@ def _count_issues(
     *,
     closed_only: bool = False,
 ) -> dict[str, int]:
-    """
-    Count issues matching a collection of LabelSpec rules.
+    """Count issues matching a collection of LabelSpec rules.
 
     Each LabelSpec represents a classification rule defined by a set of
     labels and a name. An issue is counted for a spec if its labels satisfy
@@ -51,8 +51,7 @@ def count_issues_by_label_specs(
     issues: list[IssueRecord],
     specs: tuple[LabelSpec, ...],
 ) -> dict[str, int]:
-    """
-    Count issues matching each LabelSpec classification.
+    """Count issues matching each LabelSpec classification.
 
     This function aggregates issue counts for each label specification,
     allowing datasets to be grouped by predefined label categories
@@ -77,8 +76,7 @@ def count_closed_issues_by_label_specs(
     issues: list[IssueRecord],
     specs: tuple[LabelSpec, ...],
 ) -> dict[str, int]:
-    """
-    Count closed issues matching each LabelSpec classification.
+    """Count closed issues matching each LabelSpec classification.
 
     This function behaves the same as `count_issues_by_label_specs`,
     but only includes issues whose state is "closed".

--- a/src/hiero_analytics/analysis/maintainer_pipeline.py
+++ b/src/hiero_analytics/analysis/maintainer_pipeline.py
@@ -1,4 +1,9 @@
-"""Analytics helpers for maintainer-pipeline role classification."""
+"""Analytics helpers for maintainer-pipeline role classification.
+
+This module classifies contributor activity records, including both
+pull request and issue activity, into governance roles and builds
+aggregated pipeline tables for yearly and repository-level views.
+"""
 
 from __future__ import annotations
 
@@ -8,7 +13,8 @@ from hiero_analytics.data_sources.models import ContributorActivityRecord
 
 STAGE_COLUMNS = ["general_user", "triage", "committer", "maintainer"]
 
-_PR_ACTIVITY_TYPES = {
+_MAINTAINER_ACTIVITY_TYPES = {
+    "authored_issue",
     "authored_pull_request",
     "reviewed_pull_request",
     "merged_pull_request",
@@ -23,7 +29,7 @@ def activity_to_role_dataframe(
     rows = []
 
     for record in records:
-        if record.activity_type not in _PR_ACTIVITY_TYPES:
+        if record.activity_type not in _MAINTAINER_ACTIVITY_TYPES:
             continue
 
         repo_name = record.repo.split("/")[-1]
@@ -46,7 +52,7 @@ def activity_to_role_dataframe(
 
 
 def build_maintainer_yearly_pipeline(stage_df: pd.DataFrame) -> pd.DataFrame:
-    """Build yearly contributor counts for each observed PR activity stage."""
+    """Build yearly contributor counts for each observed PR and issue activity stage."""
     if stage_df.empty:
         return pd.DataFrame(columns=["year", *STAGE_COLUMNS])
 
@@ -63,7 +69,7 @@ def build_maintainer_yearly_pipeline(stage_df: pd.DataFrame) -> pd.DataFrame:
 
 
 def build_maintainer_repo_pipeline(stage_df: pd.DataFrame) -> pd.DataFrame:
-    """Build repository-level contributor counts for each observed PR activity stage."""
+    """Build repository-level contributor counts for each observed PR and issue activity stage."""
     if stage_df.empty:
         return pd.DataFrame(columns=["repo", *STAGE_COLUMNS])
 

--- a/src/hiero_analytics/data_sources/github_ingest.py
+++ b/src/hiero_analytics/data_sources/github_ingest.py
@@ -13,8 +13,9 @@ import logging
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime, timedelta
-import requests
 from typing import TypeVar
+
+import requests
 
 from hiero_analytics.config.github import BASE_URL
 from hiero_analytics.config.paths import load_query
@@ -35,6 +36,12 @@ from .pagination import extract_graphql_cursor_page, paginate_cursor
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseRecord)
+_CONTRIBUTOR_ACTIVITY_TYPES = [
+    "authored_issue",
+    "authored_pull_request",
+    "reviewed_pull_request",
+    "merged_pull_request",
+]
 _ISSUE_TIMELINE_HEADERS = {
     "Accept": "application/vnd.github+json",
     "X-GitHub-Api-Version": "2022-11-28",
@@ -56,6 +63,17 @@ def _cache_kwargs(
         kwargs["refresh"] = True
 
     return kwargs
+
+
+def _parse_graphql_datetime(value: object) -> datetime | None:
+    """Parse an ISO datetime string from a GitHub GraphQL response."""
+    if not isinstance(value, str):
+        return None
+
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 # --------------------------------------------------------
 # GENERIC RESOURCE FETCHER ENGINE
@@ -547,6 +565,74 @@ def fetch_org_merged_pr_difficulty_graphql(
 # FETCH CONTRIBUTOR ACTIVITY
 # --------------------------------------------------------
 
+def _fetch_repo_pull_request_activity_graphql(
+    client: GitHubClient,
+    owner: str,
+    repo: str,
+    cutoff: datetime,
+) -> list[ContributorActivityRecord]:
+    """Fetch contributor activity signals from pull request lifecycle data."""
+    contributor_activity_query = load_query("contributor_activity")
+    return fetch_github_resource(
+        client,
+        contributor_activity_query,
+        {"owner": owner, "repo": repo},
+        ContributorActivityRecord,
+        ["repository", "pullRequests"],
+        cache_key="repo_contributor_pull_request_activity",
+        cache_scope=f"{owner}_{repo}",
+        cache_parameters={"owner": owner, "repo": repo},
+        context_builder=lambda _node: {
+            "owner": owner,
+            "repo": repo,
+            "cutoff": cutoff,
+            "target_type": "pull_request",
+        },
+        use_cache=False,
+    )
+
+
+def _fetch_repo_issue_activity_graphql(
+    client: GitHubClient,
+    owner: str,
+    repo: str,
+    cutoff: datetime,
+) -> list[ContributorActivityRecord]:
+    """Fetch contributor activity signals from recently opened issues."""
+    contributor_issue_activity_query = load_query("contributor_issue_activity")
+
+    def page(cursor: str | None) -> tuple[list[ContributorActivityRecord], str | None, bool]:
+        data = client.graphql(
+            contributor_issue_activity_query,
+            {"owner": owner, "repo": repo, "cursor": cursor},
+        )
+        nodes, next_cursor, has_next = extract_graphql_cursor_page(data, ["repository", "issues"])
+
+        records: list[ContributorActivityRecord] = []
+        page_has_older_issues = False
+
+        for node in nodes:
+            created_at = _parse_graphql_datetime(node.get("createdAt"))
+            if created_at is not None and created_at < cutoff:
+                page_has_older_issues = True
+
+            records.extend(
+                ContributorActivityRecord.from_github_node(
+                    node,
+                    {
+                        "owner": owner,
+                        "repo": repo,
+                        "cutoff": cutoff,
+                        "target_type": "issue",
+                    },
+                )
+            )
+
+        return records, next_cursor, has_next and not page_has_older_issues
+
+    return paginate_cursor(page)
+
+
 def fetch_repo_contributor_activity_graphql(
     client: GitHubClient,
     owner: str,
@@ -558,22 +644,52 @@ def fetch_repo_contributor_activity_graphql(
     refresh: bool = False
     ) -> list[ContributorActivityRecord]:
     """
-    Fetch contributor activity signals from pull request lifecycle data.
+    Fetch contributor activity signals from recent issue and PR lifecycle data.
+
+    Issue activity (issues opened by a contributor) and pull request
+    activity (PRs authored, reviewed, or merged) are combined into a
+    single stream of ``ContributorActivityRecord`` instances.
 
     Signals include:
+    - authored_issue (issues opened within the lookback window)
     - authored_pull_request
     - reviewed_pull_request
     - merged_pull_request
     """
-    CONTRIBUTOR_ACTIVITY_QUERY = load_query("contributor_activity")
-    cutoff = datetime.now(UTC) - timedelta(days=lookback_days)
-    return fetch_github_resource(
-        client, CONTRIBUTOR_ACTIVITY_QUERY, {"owner": owner, "repo": repo}, ContributorActivityRecord, ["repository", "pullRequests"],
-        cache_key="repo_contributor_activity", cache_scope=f"{owner}_{repo}",
-        cache_parameters={"owner": owner, "repo": repo, "lookback_days": lookback_days},
-        context_builder=lambda _node: {"owner": owner, "repo": repo, "cutoff": cutoff},
-        **_cache_kwargs(use_cache, cache_ttl_seconds, refresh),
+    cache_scope = f"{owner}_{repo}"
+    cache_parameters = {
+        "owner": owner,
+        "repo": repo,
+        "lookback_days": lookback_days,
+        "activity_types": _CONTRIBUTOR_ACTIVITY_TYPES,
+    }
+    cached = load_records_cache(
+        "repo_contributor_activity",
+        cache_scope,
+        cache_parameters,
+        ContributorActivityRecord,
+        use_cache=use_cache,
+        ttl_seconds=cache_ttl_seconds,
+        refresh=refresh,
     )
+    if cached is not None:
+        return cached
+
+    cutoff = datetime.now(UTC) - timedelta(days=lookback_days)
+    records = [
+        *_fetch_repo_pull_request_activity_graphql(client, owner, repo, cutoff),
+        *_fetch_repo_issue_activity_graphql(client, owner, repo, cutoff),
+    ]
+
+    save_records_cache(
+        "repo_contributor_activity",
+        cache_scope,
+        cache_parameters,
+        ContributorActivityRecord,
+        records,
+        use_cache=use_cache,
+    )
+    return records
 
 def fetch_org_contributor_activity_graphql(
     client: GitHubClient,
@@ -591,7 +707,12 @@ def fetch_org_contributor_activity_graphql(
         return fetch_repo_contributor_activity_graphql(client, repo.owner, repo.name, lookback_days=lookback_days, **_cache_kwargs(use_cache, cache_ttl_seconds, refresh))
     return fetch_org_resource_parallel(
         client, org, fetch_func, ContributorActivityRecord, max_workers, "org_contributor_activity",
-        {"org": org, "repos": sorted(repos) if repos else [], "lookback_days": lookback_days}, repos=repos,
+        {
+            "org": org,
+            "repos": sorted(repos) if repos else [],
+            "lookback_days": lookback_days,
+            "activity_types": _CONTRIBUTOR_ACTIVITY_TYPES,
+        }, repos=repos,
         task_desc="contributor activity",
         **_cache_kwargs(use_cache, cache_ttl_seconds, refresh),
     )

--- a/src/hiero_analytics/data_sources/github_ingest.py
+++ b/src/hiero_analytics/data_sources/github_ingest.py
@@ -1,5 +1,4 @@
-"""
-GitHub data ingestion utilities using the GraphQL API.
+"""GitHub data ingestion utilities using the GraphQL API.
 
 This module provides functions for retrieving repositories, issues, and
 merged pull request metadata from GitHub. Data is fetched using cursor-
@@ -109,6 +108,7 @@ def fetch_github_resource(  # noqa: UP047
         return cached
 
     def page(cursor: str | None) -> tuple[list[T], str | None, bool]:
+        """Fetch a single page of GraphQL results."""
         paginated_vars = dict(variables)
         paginated_vars["cursor"] = cursor
 
@@ -244,6 +244,7 @@ def fetch_org_issues_graphql(
     ) -> list[IssueRecord]:
     """Fetch all issues across all repositories in an organization."""
     def fetch_func(repo):
+        """Fetch issues for a single repository."""
         return fetch_repo_issues_graphql(client, repo.owner, repo.name, states=states, **_cache_kwargs(use_cache, cache_ttl_seconds, refresh))
     return fetch_org_resource_parallel(
         client, org, fetch_func, IssueRecord, max_workers, "org_issues",
@@ -337,6 +338,7 @@ def fetch_issue_timeline_events_rest(
     unique_issues = {(issue.repo, issue.number): issue for issue in issues}
 
     def fetch_func(issue: IssueRecord) -> list[IssueTimelineEventRecord]:
+        """Fetch timeline events for a single issue."""
         owner, repo = issue.repo.split("/", maxsplit=1)
         return fetch_repo_issue_timeline_events_rest(
             client,
@@ -492,6 +494,7 @@ def fetch_repo_issue_events_for_issues_since(
     repos = sorted({issue.repo for issue in issues})
 
     def fetch_func(full_repo: str) -> list[IssueTimelineEventRecord]:
+        """Fetch timeline events for all issues in a repository."""
         owner, repo = full_repo.split("/", maxsplit=1)
         return fetch_repo_issue_events_rest_since(
             client,
@@ -553,6 +556,7 @@ def fetch_org_merged_pr_difficulty_graphql(
     ) -> list[PullRequestDifficultyRecord]:
     """Fetch merged pull request difficulty records across all repositories in an organization."""
     def fetch_func(repo):
+        """Fetch merged PR difficulty metrics for a repository."""
         return fetch_repo_merged_pr_difficulty_graphql(client,
         repo.owner, repo.name, **_cache_kwargs(use_cache, cache_ttl_seconds, refresh))
     return fetch_org_resource_parallel(
@@ -602,6 +606,7 @@ def _fetch_repo_issue_activity_graphql(
     contributor_issue_activity_query = load_query("contributor_issue_activity")
 
     def page(cursor: str | None) -> tuple[list[ContributorActivityRecord], str | None, bool]:
+        """Fetch a single page of issues."""
         data = client.graphql(
             contributor_issue_activity_query,
             {"owner": owner, "repo": repo, "cursor": cursor},
@@ -643,8 +648,7 @@ def fetch_repo_contributor_activity_graphql(
     cache_ttl_seconds: int | None = None,
     refresh: bool = False
     ) -> list[ContributorActivityRecord]:
-    """
-    Fetch contributor activity signals from recent issue and PR lifecycle data.
+    """Fetch contributor activity signals from recent issue and PR lifecycle data.
 
     Issue activity (issues opened by a contributor) and pull request
     activity (PRs authored, reviewed, or merged) are combined into a
@@ -704,6 +708,7 @@ def fetch_org_contributor_activity_graphql(
     ) -> list[ContributorActivityRecord]:
     """Fetch contributor activity records across all repositories in an organization."""
     def fetch_func(repo):
+        """Fetch contributor activity for a repository."""
         return fetch_repo_contributor_activity_graphql(client, repo.owner, repo.name, lookback_days=lookback_days, **_cache_kwargs(use_cache, cache_ttl_seconds, refresh))
     return fetch_org_resource_parallel(
         client, org, fetch_func, ContributorActivityRecord, max_workers, "org_contributor_activity",
@@ -756,6 +761,7 @@ def fetch_org_contributor_merged_pr_count_graphql(
 ) -> list[ContributorMergedPRCountRecord]:
     """Fetch contributor merged pull request count for a specific user in an org."""
     def fetch_func(repo):
+        """Fetch merged PR counts for a contributor in a repository."""
         return fetch_repo_contributor_merged_pr_count_graphql(client,
         repo.owner, repo.name, login=login,
         **_cache_kwargs(use_cache, cache_ttl_seconds, refresh))

--- a/src/hiero_analytics/data_sources/models.py
+++ b/src/hiero_analytics/data_sources/models.py
@@ -197,6 +197,14 @@ class ContributorActivityRecord(BaseRecord):
 
     @classmethod
     def from_github_node(cls, node: dict, context: dict) -> list[ContributorActivityRecord]:
+        """Hydrate contributor activity records from a GraphQL activity node."""
+        if context.get("target_type") == "issue":
+            return cls._from_issue_node(node, context)
+
+        return cls._from_pull_request_node(node, context)
+
+    @classmethod
+    def _from_pull_request_node(cls, node: dict, context: dict) -> list[ContributorActivityRecord]:
         """Hydrate contributor activity records from a GraphQL PR node."""
         repo_name = cls._repo_name(context)
         cutoff = context.get("cutoff")
@@ -251,6 +259,30 @@ class ContributorActivityRecord(BaseRecord):
             )
         return records
 
+    @classmethod
+    def _from_issue_node(cls, node: dict, context: dict) -> list[ContributorActivityRecord]:
+        """Hydrate contributor activity records from a GraphQL issue node."""
+        repo_name = cls._repo_name(context)
+        cutoff = context.get("cutoff")
+        issue_number = node["number"]
+
+        issue_author = node.get("author", {}).get("login") if node.get("author") else None
+        issue_created_at = _parse_dt(node.get("createdAt"))
+        if not issue_created_at or (cutoff is not None and issue_created_at < cutoff) or not issue_author:
+            return []
+
+        return [
+            cls(
+                repo=repo_name,
+                activity_type="authored_issue",
+                actor=issue_author,
+                occurred_at=issue_created_at,
+                target_type="issue",
+                target_number=issue_number,
+                target_author=issue_author,
+            )
+        ]
+
 
 @dataclass(frozen=True)
 class ContributorMergedPRCountRecord(BaseRecord):
@@ -295,4 +327,3 @@ class RunnerRecord:
     job_name: str
     runner: str
     is_self_hosted: bool | None # None = undefine/fallback/env-param
-

--- a/src/hiero_analytics/data_sources/queries/contributor_issue_activity.graphql
+++ b/src/hiero_analytics/data_sources/queries/contributor_issue_activity.graphql
@@ -1,0 +1,28 @@
+query CONTRIBUTOR_ISSUE_ACTIVITY_QUERY($owner:String!, $repo:String!, $cursor:String) {
+  repository(owner:$owner, name:$repo) {
+    issues(
+      first:100
+      after:$cursor
+      states:[OPEN, CLOSED]
+      orderBy:{field:CREATED_AT, direction:DESC}
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        number
+        createdAt
+        author {
+          login
+        }
+      }
+    }
+  }
+  rateLimit{
+    limit
+    remaining
+    cost
+    resetAt
+  }
+}

--- a/src/hiero_analytics/run_maintainer_pipeline_org.py
+++ b/src/hiero_analytics/run_maintainer_pipeline_org.py
@@ -50,7 +50,7 @@ def main() -> None:
             stack_cols=STAGE_COLUMNS,
             labels=STACK_LABELS,
             colors=MAINTAINER_PIPELINE_COLORS,
-            title="Maintainer Pipeline: Unique Active Contributors by Role (Yearly)",
+            title="Maintainer Pipeline: Unique Active Contributors by Role - PR & Issue Activity (Yearly)",
             output_path=org_charts_dir / "maintainer_pipeline_yearly.png",
             annotate_totals=True,
         )
@@ -62,7 +62,7 @@ def main() -> None:
             stack_cols=STAGE_COLUMNS,
             labels=STACK_LABELS,
             colors=MAINTAINER_PIPELINE_COLORS,
-            title="Maintainer Pipeline: Unique Active Contributors by Role (by Repository)",
+            title="Maintainer Pipeline: Unique Active Contributors by Role - PR & Issue Activity (by Repository)",
             output_path=org_charts_dir / "maintainer_pipeline_by_repo.png",
             rotate_x=45,
             annotate_totals=False,

--- a/tests/analysis/test_maintainer_pipeline.py
+++ b/tests/analysis/test_maintainer_pipeline.py
@@ -13,21 +13,28 @@ from hiero_analytics.analysis.maintainer_pipeline import (
 from hiero_analytics.data_sources.models import ContributorActivityRecord
 
 
-def _record(activity_type: str, actor: str, repo: str, year: int) -> ContributorActivityRecord:
+def _record(
+    activity_type: str,
+    actor: str,
+    repo: str,
+    year: int,
+    target_type: str = "pull_request",
+) -> ContributorActivityRecord:
     return ContributorActivityRecord(
         repo=repo,
         activity_type=activity_type,
         actor=actor,
         occurred_at=datetime(year, 1, 1, tzinfo=UTC),
-        target_type="pull_request",
+        target_type=target_type,
         target_number=1,
     )
 
 
 def test_activity_to_role_dataframe_filters_unknown_types():
-    """Only PR lifecycle records should be classified into governance stages."""
-    role_lookup = {"repo-a": {"alice": "maintainer", "bob": "triage"}}
+    """Only maintainer activity records should be classified into governance stages."""
+    role_lookup = {"repo-a": {"alice": "maintainer", "bob": "triage", "dana": "committer"}}
     records = [
+        _record("authored_issue", "dana", "org/repo-a", 2024, target_type="issue"),
         _record("authored_pull_request", "alice", "org/repo-a", 2024),
         _record("reviewed_pull_request", "bob", "org/repo-a", 2024),
         _record("merged_pull_request", "carol", "org/repo-a", 2024),
@@ -36,10 +43,10 @@ def test_activity_to_role_dataframe_filters_unknown_types():
 
     df = activity_to_role_dataframe(records, role_lookup)
 
-    assert len(df) == 3
+    assert len(df) == 4
     assert set(df["repo"]) == {"repo-a"}
-    # alice → maintainer, bob → triage, carol has no entry → general_user
-    assert set(df["stage"]) == {"maintainer", "triage", "general_user"}
+    # alice -> maintainer, bob -> triage, dana -> committer, carol has no entry -> general_user
+    assert set(df["stage"]) == {"maintainer", "triage", "committer", "general_user"}
 
 
 def test_activity_to_role_dataframe_defaults_unknown_actor_to_general_user():
@@ -61,9 +68,10 @@ def test_activity_to_role_dataframe_matches_actor_case_insensitively():
 def test_build_maintainer_yearly_pipeline_counts_unique_actors_per_stage():
     """Yearly rollups should count unique actors once per stage."""
     role_lookup = {
-        "repo-a": {"alice": "general_user", "bob": "triage", "carol": "committer"}
+        "repo-a": {"alice": "general_user", "bob": "triage", "carol": "committer", "dana": "maintainer"}
     }
     records = [
+        _record("authored_issue", "dana", "org/repo-a", 2024, target_type="issue"),
         _record("authored_pull_request", "alice", "org/repo-a", 2024),
         _record("authored_pull_request", "alice", "org/repo-a", 2024),
         _record("reviewed_pull_request", "bob", "org/repo-a", 2024),
@@ -78,6 +86,7 @@ def test_build_maintainer_yearly_pipeline_counts_unique_actors_per_stage():
     assert row["general_user"] == 1
     assert row["triage"] == 1
     assert row["committer"] == 1
+    assert row["maintainer"] == 1
 
 
 def test_build_maintainer_repo_pipeline_sorts_by_total():

--- a/tests/data_sources/test_github_contributor_activity.py
+++ b/tests/data_sources/test_github_contributor_activity.py
@@ -27,38 +27,57 @@ def _to_iso(value: datetime) -> str:
 
 def test_fetch_repo_contributor_activity_graphql(mock_client, bypass_pagination):
     now = datetime.now(UTC)
+    issue_created_at = _to_iso(now - timedelta(days=6))
     created_at = _to_iso(now - timedelta(days=5))
     reviewed_at = _to_iso(now - timedelta(days=4))
     merged_at = _to_iso(now - timedelta(days=3))
 
-    mock_client.graphql.return_value = {
-        "data": {
-            "repository": {
-                "pullRequests": {
-                    "nodes": [
-                        {
-                            "number": 10,
-                            "createdAt": created_at,
-                            "updatedAt": merged_at,
-                            "mergedAt": merged_at,
-                            "author": {"login": "alice"},
-                            "mergedBy": {"login": "carol"},
-                            "reviews": {
-                                "nodes": [
-                                    {
-                                        "state": "APPROVED",
-                                        "submittedAt": reviewed_at,
-                                        "author": {"login": "bob"},
-                                    }
-                                ]
-                            },
-                        }
-                    ],
-                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+    mock_client.graphql.side_effect = [
+        {
+            "data": {
+                "repository": {
+                    "pullRequests": {
+                        "nodes": [
+                            {
+                                "number": 10,
+                                "createdAt": created_at,
+                                "updatedAt": merged_at,
+                                "mergedAt": merged_at,
+                                "author": {"login": "alice"},
+                                "mergedBy": {"login": "carol"},
+                                "reviews": {
+                                    "nodes": [
+                                        {
+                                            "state": "APPROVED",
+                                            "submittedAt": reviewed_at,
+                                            "author": {"login": "bob"},
+                                        }
+                                    ]
+                                },
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
                 }
             }
-        }
-    }
+        },
+        {
+            "data": {
+                "repository": {
+                    "issues": {
+                        "nodes": [
+                            {
+                                "number": 20,
+                                "createdAt": issue_created_at,
+                                "author": {"login": "dana"},
+                            }
+                        ],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        },
+    ]
 
     records = ingest.fetch_repo_contributor_activity_graphql(
         mock_client,
@@ -68,13 +87,59 @@ def test_fetch_repo_contributor_activity_graphql(mock_client, bypass_pagination)
         use_cache=False,
     )
 
-    assert len(records) == 3
+    assert len(records) == 4
     assert all(isinstance(record, ContributorActivityRecord) for record in records)
     assert {record.activity_type for record in records} == {
+        "authored_issue",
         "authored_pull_request",
         "reviewed_pull_request",
         "merged_pull_request",
     }
+    issue_record = next(record for record in records if record.activity_type == "authored_issue")
+    assert issue_record.actor == "dana"
+    assert issue_record.target_type == "issue"
+    assert issue_record.target_number == 20
+    assert "states:[OPEN, CLOSED]" in mock_client.graphql.call_args_list[1].args[0]
+
+
+def test_fetch_repo_issue_activity_graphql_stops_after_older_issue(mock_client):
+    now = datetime.now(UTC)
+    recent_issue_created_at = _to_iso(now - timedelta(days=5))
+    older_issue_created_at = _to_iso(now - timedelta(days=40))
+
+    mock_client.graphql.return_value = {
+        "data": {
+            "repository": {
+                "issues": {
+                    "nodes": [
+                        {
+                            "number": 20,
+                            "createdAt": recent_issue_created_at,
+                            "author": {"login": "dana"},
+                        },
+                        {
+                            "number": 21,
+                            "createdAt": older_issue_created_at,
+                            "author": {"login": "erin"},
+                        },
+                    ],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "next-page"},
+                }
+            }
+        }
+    }
+
+    records = ingest._fetch_repo_issue_activity_graphql(
+        mock_client,
+        "org",
+        "repo",
+        cutoff=now - timedelta(days=30),
+    )
+
+    assert len(records) == 1
+    assert records[0].activity_type == "authored_issue"
+    assert records[0].actor == "dana"
+    assert mock_client.graphql.call_count == 1
 
 
 def test_fetch_org_contributor_activity_graphql(monkeypatch, mock_client):

--- a/tests/data_sources/test_github_contributor_activity.py
+++ b/tests/data_sources/test_github_contributor_activity.py
@@ -1,3 +1,4 @@
+"""Tests for GitHub contributor activity ingestion."""
 from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock
 
@@ -9,11 +10,13 @@ from hiero_analytics.data_sources.models import ContributorActivityRecord, Repos
 
 @pytest.fixture
 def mock_client():
+    """Mock GitHub client fixture."""
     return Mock()
 
 
 @pytest.fixture
 def bypass_pagination(monkeypatch):
+    """Bypass pagination to return a single page."""
     monkeypatch.setattr(
         ingest,
         "paginate_cursor",
@@ -26,6 +29,7 @@ def _to_iso(value: datetime) -> str:
 
 
 def test_fetch_repo_contributor_activity_graphql(mock_client, bypass_pagination):
+    """Test fetching repository contributor activity."""
     now = datetime.now(UTC)
     issue_created_at = _to_iso(now - timedelta(days=6))
     created_at = _to_iso(now - timedelta(days=5))
@@ -103,6 +107,7 @@ def test_fetch_repo_contributor_activity_graphql(mock_client, bypass_pagination)
 
 
 def test_fetch_repo_issue_activity_graphql_stops_after_older_issue(mock_client):
+    """Test early stop for older issues in pagination."""
     now = datetime.now(UTC)
     recent_issue_created_at = _to_iso(now - timedelta(days=5))
     older_issue_created_at = _to_iso(now - timedelta(days=40))
@@ -143,6 +148,7 @@ def test_fetch_repo_issue_activity_graphql_stops_after_older_issue(mock_client):
 
 
 def test_fetch_org_contributor_activity_graphql(monkeypatch, mock_client):
+    """Test fetching organization contributor activity."""
     repos = [
         RepositoryRecord("org/repo1", "repo1", "org"),
         RepositoryRecord("org/repo2", "repo2", "org"),

--- a/tests/data_sources/test_github_rest.py
+++ b/tests/data_sources/test_github_rest.py
@@ -1,3 +1,4 @@
+"""Tests for GitHub REST API interactions."""
 from unittest.mock import Mock
 
 import pytest
@@ -10,14 +11,13 @@ import hiero_analytics.data_sources.github_search as search
 
 @pytest.fixture
 def mock_client():
+    """Mock GitHub client fixture."""
     return Mock()
 
 
 @pytest.fixture
 def bypass_pagination(monkeypatch):
-    """
-    Replace paginate_page_number so only one page runs.
-    """
+    """Replace paginate_page_number so only one page runs."""
     monkeypatch.setattr(
         search,
         "paginate_page_number",
@@ -30,7 +30,7 @@ def bypass_pagination(monkeypatch):
 # --------------------------------------------------------
 
 def test_search_issues_returns_items(mock_client, bypass_pagination):
-
+    """Test searching issues returns correctly mapped items."""
     mock_client.get.return_value = {
         "items": [
             {"id": 1, "title": "Issue A"},
@@ -49,7 +49,7 @@ def test_search_issues_returns_items(mock_client, bypass_pagination):
 # --------------------------------------------------------
 
 def test_search_issues_calls_client_with_correct_params(mock_client, bypass_pagination):
-
+    """Test searching issues calls client with proper request parameters."""
     mock_client.get.return_value = {"items": []}
 
     search.search_issues(mock_client, "repo:org/repo is:issue")
@@ -72,7 +72,7 @@ def test_search_issues_calls_client_with_correct_params(mock_client, bypass_pagi
 # --------------------------------------------------------
 
 def test_search_issues_filters_non_dict_items(mock_client, bypass_pagination):
-
+    """Test searching issues filters out invalid non-dictionary items."""
     mock_client.get.return_value = {
         "items": [
             {"id": 1},
@@ -93,7 +93,7 @@ def test_search_issues_filters_non_dict_items(mock_client, bypass_pagination):
 # --------------------------------------------------------
 
 def test_search_issues_handles_missing_items(mock_client, bypass_pagination):
-
+    """Test searching issues gracefully handles missing items key in response."""
     mock_client.get.return_value = {}
 
     results = search.search_issues(mock_client, "test")
@@ -106,7 +106,7 @@ def test_search_issues_handles_missing_items(mock_client, bypass_pagination):
 # --------------------------------------------------------
 
 def test_search_issues_uses_paginator(monkeypatch, mock_client):
-
+    """Test searching issues uses the paginator helper."""
     called = {"value": False}
 
     def fake_paginator(page_fn, **_kwargs):

--- a/tests/data_sources/test_github_rest.py
+++ b/tests/data_sources/test_github_rest.py
@@ -21,7 +21,7 @@ def bypass_pagination(monkeypatch):
     monkeypatch.setattr(
         search,
         "paginate_page_number",
-        lambda f: f(1),
+        lambda f, **_kwargs: f(1),
     )
 
 
@@ -109,7 +109,7 @@ def test_search_issues_uses_paginator(monkeypatch, mock_client):
 
     called = {"value": False}
 
-    def fake_paginator(page_fn):
+    def fake_paginator(page_fn, **_kwargs):
         called["value"] = True
         return page_fn(1)
 

--- a/tests/data_sources/test_models.py
+++ b/tests/data_sources/test_models.py
@@ -125,6 +125,35 @@ def test_contributor_activity_record_creation():
     assert record.target_number == 10
 
 
+def test_contributor_activity_record_from_issue_node():
+    """Contributor activity records should hydrate issue creation events."""
+    records = ContributorActivityRecord.from_github_node(
+        {
+            "number": 12,
+            "createdAt": "2024-01-02T00:00:00Z",
+            "author": {"login": "dana"},
+        },
+        {
+            "owner": "org",
+            "repo": "repo",
+            "target_type": "issue",
+            "cutoff": datetime.fromisoformat("2024-01-01T00:00:00+00:00"),
+        },
+    )
+
+    assert records == [
+        ContributorActivityRecord(
+            repo="org/repo",
+            activity_type="authored_issue",
+            actor="dana",
+            occurred_at=datetime.fromisoformat("2024-01-02T00:00:00+00:00"),
+            target_type="issue",
+            target_number=12,
+            target_author="dana",
+        )
+    ]
+
+
 def test_issue_timeline_event_record_creation():
     """Issue timeline records should preserve normalized event metadata."""
     occurred = datetime(2024, 1, 1)
@@ -249,4 +278,3 @@ def test_parse_dt():
 def test_parse_dt_none():
     """A missing timestamp should remain missing."""
     assert _parse_dt(None) is None
-


### PR DESCRIPTION
This PR enhances the maintainer activity pipeline by including issue creation activity alongside the existing pull request lifecycle signals.

Previously, the pipeline treated contributors as active only when they authored, reviewed, or merged pull requests. That missed an important part of real maintainer and contributor work: opening issues, reporting problems, starting discussions, and helping surface work for the project. With this change, issue authors are now included as authored_issue activity within the same existing maintainer lookback window.

This keeps the pipeline aligned with the discussion in #131: comment activity is intentionally left out for now because it could create a large and harder-to-verify dataset. The implementation stays focused on issue creation activity only.

Changes

- Added authored_issue as a maintainer activity type.
- Added a GraphQL query for issue activity using states:[OPEN, CLOSED].
- Hydrated ContributorActivityRecord instances from issue GraphQL nodes.
- Combined PR lifecycle activity and issue creation activity in fetch_repo_contributor_activity_graphql.
- Preserved the existing 183 day lookback window.
- Updated maintainer pipeline aggregation so issue authors are counted in their governance stage.
- Updated chart titles and maintainer pipeline documentation to reflect the combined PR and issue activity scope.
- Added tests covering issue activity hydration, fetching, filtering, and role aggregation.

Validation

Full test suite passes: 127 passed
Touched production source files pass ruff check
compileall passes
git diff --check passes


Closes #131