### PR TITLE
refactor: replace timezone.utc with UTC alias across three files

### DIFF
--- a/src/hiero_analytics/analysis/maintainer_pipeline.py
+++ b/src/hiero_analytics/analysis/maintainer_pipeline.py
@@ -7,7 +7,7 @@ aggregated pipeline tables for yearly and repository-level views.
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pandas as pd
 
@@ -46,9 +46,9 @@ def activity_to_role_dataframe(
         # a naive-vs-aware mismatch.
         occurred_at = record.occurred_at
         if occurred_at.tzinfo is None:
-            occurred_at = occurred_at.replace(tzinfo=timezone.utc)
+            occurred_at = occurred_at.replace(tzinfo=UTC)
         else:
-            occurred_at = occurred_at.astimezone(timezone.utc)
+            occurred_at = occurred_at.astimezone(UTC)
 
         return {
             "repo": repo_name,
@@ -76,8 +76,8 @@ def _active_window_for_year(
     """
     if year < today.year:
         # Past year: fixed last-6-months window, immune to re-run date.
-        window_start = datetime(year, 7, 1, tzinfo=timezone.utc)
-        window_end = datetime(year, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+        window_start = datetime(year, 7, 1, tzinfo=UTC)
+        window_end = datetime(year, 12, 31, 23, 59, 59, tzinfo=UTC)
     else:
         # Current year: trailing window from today.
         window_end = today
@@ -100,7 +100,7 @@ def build_maintainer_yearly_pipeline(
     if stage_df.empty:
         return pd.DataFrame(columns=["year", *STAGE_COLUMNS])
 
-    today = datetime.now(timezone.utc)
+    today = datetime.now(UTC)
     years = stage_df["year"].unique()
 
     filtered_frames: list[pd.DataFrame] = []
@@ -141,7 +141,7 @@ def build_maintainer_repo_pipeline(
     if stage_df.empty:
         return pd.DataFrame(columns=["repo", *STAGE_COLUMNS])
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=active_window_days)
+    cutoff = datetime.now(UTC) - timedelta(days=active_window_days)
     active_df = stage_df[stage_df["occurred_at"] >= cutoff]
 
     if active_df.empty:

--- a/src/hiero_analytics/data_sources/rate_limit.py
+++ b/src/hiero_analytics/data_sources/rate_limit.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum, auto
 from typing import Any
 
@@ -65,7 +65,7 @@ class RateLimitSnapshot:
             return None
 
         reset_at = (
-            datetime.fromtimestamp(reset_epoch, tz=timezone.utc)
+            datetime.fromtimestamp(reset_epoch, tz=UTC)
             if reset_epoch is not None
             else None
         )
@@ -99,7 +99,7 @@ class RateLimitSnapshot:
         """Seconds until the budget window resets (0 if unknown or already passed)."""
         if self.reset_at is None:
             return 0
-        return max(0, int((self.reset_at - datetime.now(timezone.utc)).total_seconds()))
+        return max(0, int((self.reset_at - datetime.now(UTC)).total_seconds()))
 
 
 # --------------------------------------------------------

--- a/tests/analysis/test_maintainer_pipeline.py
+++ b/tests/analysis/test_maintainer_pipeline.py
@@ -1,6 +1,6 @@
 """Tests for maintainer-pipeline aggregations."""
 
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pandas as pd
@@ -149,16 +149,16 @@ def test_build_maintainer_repo_pipeline_excludes_inactive():
 
 def test_active_window_for_completed_year_is_fixed_h2():
     """Completed years should use a fixed July-1 to Dec-31 window."""
-    today = datetime(2026, 4, 24, tzinfo=timezone.utc)
+    today = datetime(2026, 4, 24, tzinfo=UTC)
     start, end = _active_window_for_year(2025, today)
 
-    assert start == datetime(2025, 7, 1, tzinfo=timezone.utc)
-    assert end == datetime(2025, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+    assert start == datetime(2025, 7, 1, tzinfo=UTC)
+    assert end == datetime(2025, 12, 31, 23, 59, 59, tzinfo=UTC)
 
 
 def test_active_window_for_current_year_is_trailing_183_days():
     """The current (incomplete) year should use a trailing 183-day window."""
-    today = datetime(2026, 4, 24, tzinfo=timezone.utc)
+    today = datetime(2026, 4, 24, tzinfo=UTC)
     start, end = _active_window_for_year(2026, today)
 
     assert end == today
@@ -193,9 +193,9 @@ def test_yearly_pipeline_historical_bars_are_stable():
     stage_df = activity_to_role_dataframe(records, role_lookup)
 
     # Simulate pipeline run in April 2026.
-    today_apr_2026 = datetime(2026, 4, 24, tzinfo=timezone.utc)
+    today_apr_2026 = datetime(2026, 4, 24, tzinfo=UTC)
     # Simulate pipeline run in October 2026.
-    today_oct_2026 = datetime(2026, 10, 1, tzinfo=timezone.utc)
+    today_oct_2026 = datetime(2026, 10, 1, tzinfo=UTC)
 
     with patch("hiero_analytics.analysis.maintainer_pipeline.datetime") as mock_dt:
         mock_dt.now.return_value = today_apr_2026


### PR DESCRIPTION
**Description:**

Summary:
Python 3.11 introduced datetime.UTC as a direct alias for timezone.utc. The ruff linter (targeting Python 3.14) flags timezone.utc as deprecated, this PR eliminates all three flagged usages to align with the modern pattern already established throughout the rest of the codebase.

**Changes:**
src/hiero_analytics/data_sources/rate_limit.py: updated import and replaced 2 occurrences of timezone.utc
src/hiero_analytics/analysis/maintainer_pipeline.py: updated import and replaced 6 occurrences of timezone.utc
tests/analysis/test_maintainer_pipeline.py: removed unused timezone import, replaced 6 occurrences of timezone.utc

**Notes:**
Purely mechanical find-and-replace. UTC and timezone.utc are semantically identical — no functional changes.

Closes #215



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UTC handling for timestamp, cutoff, and rate-limit calculations to keep date-based behavior consistent across environments.
  * Ensured time-related calculations use a single UTC standard, reducing potential issues around timezone handling.
* **Tests**
  * Updated time-related tests to match the new UTC handling and verify historical date calculations remain stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->