### PR TITLE
 Resolve the bug to ensure a branch is deleted after merging

### DIFF
--- a/.github/workflows/update-analytics.yml
+++ b/.github/workflows/update-analytics.yml
@@ -153,7 +153,7 @@ jobs:
             - Updated CODEOWNERS compliance and runner-type reports
 
             **Note:** This is an automated PR. Please review the changes before merging.
-          branch: analytics-refresh-${{ github.run_number }}
+          branch: analytics-refresh
           delete-branch: true
           labels: |
             automated


### PR DESCRIPTION
Fix the bug where the analytics-refresh branch remains after merging

Fixes: