### PR TITLE
Rename project to hiero_analytics in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "hiero"
+name = "hiero_analytics"
 dynamic = ["version"]
 description = "Hiero analytics"
 maintainers = [


### PR DESCRIPTION
## Summary
- Renamed the project name in `pyproject.toml` from `hiero` to `hiero_analytics`.

Closes #269