### PR TITLE
Feat/split contributors governance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ src/hiero_sdk_python/hapi
 
 # Pytest
 .pytest_cache
-
 # Lock files
 # uv.lock is committed on purpose: it pins exact transitive versions for
 # reproducible installs and satisfies OpenSSF Scorecard's Pinned-Dependencies.
@@ -58,3 +57,5 @@ inputs/
 
 # Assembled GitHub Pages site (built in CI from the dashboard; never committed)
 _site/
+
+.claude

--- a/src/hiero_analytics/config/analysis.py
+++ b/src/hiero_analytics/config/analysis.py
@@ -19,10 +19,12 @@ LOAD_SHARE_MIN_ACTIONS = 20
 # Maintainer-coverage flag: surface repos with at most this many *active* maintainers.
 UNDERSTAFFED_MAX_ACTIVE_MAINTAINERS = 1
 
-# Maintainer co-membership network: min shared maintainers for a repo-repo link
-# (the only role network still rendered; raise to thin a dense group).
+# Role co-membership networks: min shared members for a repo-repo link, per
+# governance role (raise to thin a dense group into something readable).
 ROLE_NETWORK_MIN_SHARED = {
     "maintainer": env_int("NETWORK_MIN_SHARED", 1, minimum=1),
+    "committer": env_int("NETWORK_MIN_SHARED_COMMITTER", 1, minimum=1),
+    "triage": env_int("NETWORK_MIN_SHARED_TRIAGE", 1, minimum=1),
 }
 
 # All-contributors network: one link per this many repos (scales the threshold to org

--- a/src/hiero_analytics/config/github.py
+++ b/src/hiero_analytics/config/github.py
@@ -24,7 +24,7 @@ SECONDARY_RATE_LIMIT_FALLBACK_SECONDS = 30
 # Collapses network round-trips (cost in rate-limit points is roughly the sum of
 # the parts either way). Kept moderate so per-query node/complexity limits stay
 # far away even for issue-heavy repos.
-GITHUB_GRAPHQL_BATCH_SIZE = env_int("GITHUB_GRAPHQL_BATCH_SIZE", 10, minimum=1)
+GITHUB_GRAPHQL_BATCH_SIZE = env_int("GITHUB_GRAPHQL_BATCH_SIZE", 5, minimum=1)
 
 # Default concurrency for org-wide parallel fetches. GitHub's secondary (abuse)
 # rate limit is triggered by request burst/concurrency, not just hourly quota,

--- a/src/hiero_analytics/dashboard_spec/__init__.py
+++ b/src/hiero_analytics/dashboard_spec/__init__.py
@@ -1,28 +1,29 @@
 """Declarative spec for the dashboard — one module per dashboard family.
 
 Pure data consumed by the dashboard pipeline. Each family module declares its
-chart macro plus the notes/methodology/wide-chart sets for its charts; the
-contributors module also owns the table sections. This package assembles the
-families in display order (helpers in ``_assembly``) and exposes the same
-names the single-module spec did, so consumers import from
-``hiero_analytics.dashboard_spec`` unchanged.
+chart macro plus the notes/methodology/wide-chart sets for its charts; a
+family with table sections (contributors, governance) also declares
+``SECTION_SPECS``/``SECTION_GROUPS``. This package assembles the families in
+display order (helpers in ``_assembly``) and exposes the table-bearing
+families per macro name, so the dashboard pipeline renders each family's
+tables inside its own macro.
 """
 
 from __future__ import annotations
 
-from hiero_analytics.dashboard_spec import community, contributors, onboarding, security
+from hiero_analytics.dashboard_spec import community, contributors, governance, onboarding, security
 from hiero_analytics.dashboard_spec._assembly import canonical_macro, merged
 
 # Macro (family) display order.
-_FAMILIES = (contributors, onboarding, security, community)
+_FAMILIES = (contributors, governance, onboarding, security, community)
 
-AFFILIATION_ISSUE_URL = contributors.AFFILIATION_ISSUE_URL
-MACRO_NAME = contributors.MACRO_NAME
-SECTION_SPECS = contributors.SECTION_SPECS
-SECTION_GROUPS = contributors.SECTION_GROUPS
-SECTION_ORDER = contributors.SECTION_ORDER
-SECTION_GROUP_OF = contributors.SECTION_GROUP_OF
+AFFILIATION_ISSUE_URL = governance.AFFILIATION_ISSUE_URL
 CHARTS_GROUP = "Charts"
+
+# The families that carry table sections, keyed by their macro name — the
+# dashboard pipeline reads SECTION_SPECS / SECTION_ORDER / SECTION_GROUP_OF
+# off each. A family without tables simply isn't listed.
+TABLE_FAMILIES = {family.CHART_MACRO["name"]: family for family in _FAMILIES if hasattr(family, "SECTION_SPECS")}
 
 CHART_MACROS = [canonical_macro(family.CHART_MACRO) for family in _FAMILIES]
 CHART_NOTES = merged(_FAMILIES, "CHART_NOTES")

--- a/src/hiero_analytics/dashboard_spec/contributors.py
+++ b/src/hiero_analytics/dashboard_spec/contributors.py
@@ -1,61 +1,31 @@
-"""Contributors & governance — the primary dashboard family.
+"""Contributors — the people and their activity.
 
-Owns the table sections (and their grouping) as well as its chart macro,
-notes and methodology. Pure data; see the package __init__ for assembly.
+The community-focused family: who contributes, how activity moves month to
+month, and how repositories connect through shared people. Authority, coverage
+risk, and employer concentration live in the governance family. Pure data; see
+the package __init__ for assembly.
 """
 
 from __future__ import annotations
 
-# "Suggest a correction" target for the affiliations reference table — the analytics
-# repo's issues page. The affiliations map is the source of truth, so a correction is
-# either a one-line edit to data/affiliations.yaml (append '# manual') or a new issue here.
-AFFILIATION_ISSUE_URL = "https://github.com/hiero-hackers/analytics/issues"
-
-# The dashboard is organized as macro (family) → org → section. Today there is a
-# single macro built from SECTION_SPECS below; a future dashboard family (e.g.
-# onboarding, scorecards) becomes a new macro: build its ``org_tabs`` the same way
-# and append ``{"name": ..., "org_tabs": [...]}`` to ``macros`` in main(). The macro
-# tab bar appears automatically once there is more than one.
-MACRO_NAME = "Contributors & governance"
-
-# This family's chart sections, per org (see CHART_MACROS in the package
-# __init__ for how families are assembled and ordered).
 CHART_MACRO = {
-    "name": MACRO_NAME,
+    "name": "Contributors",
     "charts": {
         "hiero-ledger": [
-            {
-                "id": "maintainer-pipeline",
-                "title": "Maintainer pipeline",
-                "description": "How the maintainer/committer pipeline has moved over time and across repos.",
-                # One chart, four views: a tab switcher (By year / month / week / repo)
-                # shows a single chart at a time instead of stacking all four.
-                "files": [
-                    (
-                        "Unique active contributors by role",
-                        [
-                            ("By year", "maintainer_pipeline_yearly.png"),
-                            ("By month", "maintainer_pipeline_monthly.png"),
-                            ("By week", "maintainer_pipeline_weekly.png"),
-                            ("By repo", "maintainer_pipeline_by_repo.png"),
-                        ],
-                    ),
-                ],
-            },
             {
                 "id": "role-networks",
                 "title": "Activity networks by role",
                 "slideshow": True,
                 "description": (
-                    "Repositories linked by the people they share, one slide per group (maintainers, "
-                    "the smallest and most governance-relevant group, and all contributors, the widest "
-                    "view). Each bubble is a repo sized by that group's active members; links mean "
-                    "shared members (thicker = more). Colour = repository type. Use Prev/Next; click to "
-                    "enlarge."
+                    "Repositories linked by the people they share, one slide per group (all "
+                    "contributors first — the widest view — then maintainers, the smallest and most "
+                    "governance-relevant group). Each bubble is a repo sized by that group's active "
+                    "members; links mean shared members (thicker = more). Colour = repository type. "
+                    "Use Prev/Next; click to enlarge."
                 ),
                 "files": [
-                    ("Maintainers", "maintainer_network.png"),
                     ("All contributors", "all_network.png"),
+                    ("Maintainers", "maintainer_network.png"),
                 ],
             },
             {
@@ -66,66 +36,13 @@ CHART_MACRO = {
                     "Weighted monthly activity over the last six months (greener = more active). Slide "
                     "through the same activity zooming steadily out — from each individual contributor, "
                     "to their governance team, to their employer, and finally to the repositories the "
-                    "work lands in."
+                    "work lands in. For employer concentration and authority risk, see the Governance tab."
                 ),
                 "files": [
                     ("By contributor", "contributor_activity_heatmap.png"),
                     ("By team", "team_activity_heatmap.png"),
                     ("By organisation", "org_activity_heatmap.png"),
                     ("By repository", "repo_activity_heatmap.png"),
-                ],
-            },
-            {
-                "id": "org-diversity",
-                "title": "Organisation diversity",
-                "description": (
-                    "Where maintainer authority sits — org-wide, per team and per repo. The first chart is "
-                    "the ecosystem-wide split of maintainers by employer (solo contributors pooled as "
-                    "'Independent'); the next two count the governance teams and the repositories that a "
-                    "single employer solely controls (an organisational bus-factor); the last two break "
-                    "down each repository's and each team's maintainer mix. See the affiliations and "
-                    "repo-diversity tables for the underlying detail."
-                ),
-                # Each chart offers an All / Active (last 90 days) tab so the roster
-                # and the day-to-day active core can be compared in place.
-                # The compact charts share the top rows; the two wide
-                # composition charts then stack full-width, one row each.
-                "files": [
-                    (
-                        "Maintainers by organisation",
-                        [
-                            ("All", "affiliation_donut.png"),
-                            ("Active 90d", "affiliation_donut_active.png"),
-                        ],
-                    ),
-                    (
-                        "Single-employer teams by org",
-                        [
-                            ("All", "single_employer_teams_by_org.png"),
-                            ("Active 90d", "single_employer_teams_by_org_active.png"),
-                        ],
-                    ),
-                    (
-                        "Single-employer repos by org",
-                        [
-                            ("All", "single_employer_repos_by_org.png"),
-                            ("Active 90d", "single_employer_repos_by_org_active.png"),
-                        ],
-                    ),
-                    (
-                        "Organisation mix by repo",
-                        [
-                            ("All", "repo_affiliation_composition.png"),
-                            ("Active 90d", "repo_affiliation_composition_active.png"),
-                        ],
-                    ),
-                    (
-                        "Organisation mix by team",
-                        [
-                            ("All", "team_affiliation_composition.png"),
-                            ("Active 90d", "team_affiliation_composition_active.png"),
-                        ],
-                    ),
                 ],
             },
         ],
@@ -166,8 +83,7 @@ CHART_MACRO = {
 }
 
 # Each section: which CSV it reads and how to render it. Sections appear only when
-# their CSV exists and is non-empty, so governance-only tables (role coverage,
-# teams) are simply absent for orgs without a governance config.
+# their CSV exists and is non-empty.
 SECTION_SPECS = [
     {
         "id": "profiles",
@@ -186,287 +102,21 @@ SECTION_SPECS = [
             ("last_active", "last active"),
         ],
     },
-    {
-        "id": "repoactivity",
-        "file": "repo_activity_overview.csv",
-        "periods": True,
-        "title": "Repository activity — permission-holders by role",
-        "description": (
-            "One row per repo: how many maintainers, committers and triage hold it, how many "
-            "are active in the selected period, and activity split by role. Sorted by activity "
-            "within that period. 'actions' = PRs + reviews + merges + issues + labels, summed."
-        ),
-        "columns": [
-            ("repo", "repo"),
-            ("maintainers", "maintainers"),
-            ("committers", "committers"),
-            ("triage", "triage"),
-            ("active_recent", "active"),
-            ("maintainer_actions_recent", "maint. actions"),
-            ("committer_actions_recent", "comm. actions"),
-            ("triage_actions_recent", "triage actions"),
-            ("actions_recent", "actions"),
-            ("last_active", "last active"),
-        ],
-    },
-    {
-        "id": "understaffed",
-        "file": "maintainer_coverage_risk.csv",
-        "periods": True,
-        "title": "Repos with one or fewer active maintainers",
-        "description": (
-            "Repos where at most one maintainer has been active in the selected period. 'maintainers' is "
-            "the total on paper; 'committers' and 'triage' show others with access to the repo. Fewest "
-            "active maintainers first."
-        ),
-        "columns": [
-            ("repo", "repo"),
-            ("maintainers", "maintainers"),
-            ("active_maintainers", "active maintainers"),
-            ("committers", "committers"),
-            ("triage", "triage"),
-        ],
-    },
-    {
-        "id": "loadshare",
-        "file": "review_load_share.csv",
-        "periods": True,
-        "title": "Who carries the review load",
-        "description": (
-            "For each repo, the share of review+merge work in the selected period done by the single busiest "
-            "person who can merge — committer or maintainer. 'mergers' is how many reviewed/merged; "
-            "'top role' is whether the busiest is a committer or maintainer; 'top %' is their share, "
-            "'top-2 %' the top two combined. Highest concentration first; repos with under 20 recent "
-            "review+merge actions are omitted."
-        ),
-        "columns": [
-            ("repo", "repo"),
-            ("mergers", "mergers"),
-            ("load_recent", "review+merge"),
-            ("top_carrier", "top carrier"),
-            ("top_role", "top role"),
-            ("top_pct", "top %"),
-            ("top2_pct", "top-2 %"),
-        ],
-    },
-    {
-        "id": "repo",
-        "file": "role_coverage_all.csv",
-        "periods": True,
-        "title": "Roles and recent activity by repo",
-        "description": (
-            "Type a repo to see its permission-holders and their contributions in this repo "
-            "during the selected period, plus whether each has activity here in that period. "
-            "Days since active always refers to the latest recorded activity."
-        ),
-        "columns": [
-            ("repo", "repo"),
-            ("user", "user"),
-            ("granted_role", "role"),
-            ("status", "status"),
-            ("days_since_active", "days since active"),
-            ("prs_recent", "PRs"),
-            ("reviews_recent", "reviews"),
-            ("merges_recent", "merges"),
-            ("issues_recent", "issues"),
-            ("labels_recent", "labels"),
-        ],
-    },
-    {
-        "id": "affiliations",
-        "file": "maintainer_affiliations.csv",
-        "title": "Maintainer affiliations — reference",
-        "description": (
-            "Reference: each maintainer, the organisation they were mapped to, and how it was decided — "
-            "'automated' (the resolver placed them from public signals) or 'manual' (a hand-correction). "
-            "Status is 'affiliated' (named employer), 'independent' (solo / personal-email only), or "
-            "'unknown' (no public signal). To fix a mapping or resolve an unknown, edit its row in "
-            "data/affiliations.yaml and append '# manual: reason' (it then survives regeneration and reads "
-            "'manual' here), or use 'Suggest a correction' to open an issue on the analytics repo."
-        ),
-        "action_url": AFFILIATION_ISSUE_URL,
-        "action_label": "Suggest a correction",
-        "columns": [
-            ("login", "maintainer"),
-            ("organisation", "organisation"),
-            ("status", "status"),
-            ("method", "method"),
-        ],
-    },
-    {
-        "id": "repodiversity",
-        "file": "repo_affiliation_diversity.csv",
-        "title": "Maintainer organisation diversity by repo",
-        "description": (
-            "Per repo: how many maintainers it has, how many distinct employers they span, the largest "
-            "employer and its share of resolved (mapped) maintainers — the same definition as the team "
-            "table — and the independent / unknown counts. Repos where one employer holds every maintainer "
-            "seat ('distinct orgs' = 1) are an organisational bus-factor. Single-employer repos first."
-        ),
-        "columns": [
-            ("repo", "repo"),
-            ("maintainers", "maintainers"),
-            ("distinct_orgs", "distinct orgs"),
-            ("top_org", "largest org"),
-            ("top_org_pct", "largest org %"),
-            ("independent", "independent"),
-            ("unknown", "unknown"),
-            ("organisations", "organisations"),
-        ],
-    },
-    {
-        "id": "teamdiversity",
-        "file": "team_affiliation_diversity.csv",
-        "title": "Team organisation concentration",
-        "description": (
-            "Per governance team: how many members resolve to an employer, how many distinct employers "
-            "they span, the largest employer and its share, and the concentration (HHI, 10000 = one "
-            "employer). 'single employer' = one employer holds every resolved seat — a capture / "
-            "bus-factor risk, most serious for admin, release, security, and maintainer teams; teams with "
-            "more unmapped than resolved members are never flagged. 'unknown' "
-            "is how many members aren't in the affiliations map (mostly non-maintainers), so read a flag "
-            "on a mostly-unknown team with caution. Most concentrated first."
-        ),
-        "columns": [
-            ("team", "team"),
-            ("members", "members"),
-            ("resolved", "resolved"),
-            ("distinct_orgs", "distinct orgs"),
-            ("top_org", "largest org"),
-            ("top_org_pct", "largest org %"),
-            ("hhi", "HHI"),
-            ("unknown", "unknown"),
-            ("single_employer", "single employer"),
-            ("organisations", "organisation mix"),
-        ],
-    },
-    {
-        "id": "gonedark",
-        "file": "role_coverage_globally_quiet.csv",
-        "title": "Permission-holders with no recent activity (180+ days)",
-        "description": (
-            "Permission-holders with no recorded activity in any repo in the last 180 days. "
-            "Useful for keeping access lists current. A blank 'days since active' means no "
-            "recorded activity yet."
-        ),
-        "columns": [
-            ("user", "user"),
-            ("highest_role", "highest role"),
-            ("roles", "roles held"),
-            ("repos_held", "repos"),
-            ("days_since_active", "days since active"),
-            ("last_active", "last active"),
-        ],
-    },
-    {
-        "id": "tscrepo",
-        "file": "tsc_activity_by_repo.csv",
-        "title": "TSC activity by repo (all-time)",
-        "description": "For TSC members with activity, which repos they work in and the role they hold there.",
-        "columns": [
-            ("account", "member"),
-            ("repo", "repo"),
-            ("repo_role", "role here"),
-            ("prs_opened", "PRs"),
-            ("reviews_given", "reviews"),
-            ("merges_done", "merges"),
-            ("issues_opened", "issues"),
-            ("labels_applied", "labels"),
-            ("last_active", "last active"),
-        ],
-    },
-    {
-        "id": "teams",
-        "file": "team_activity_summary.csv",
-        "periods": True,
-        "title": "Team activity overview",
-        "description": (
-            "Each governance team's size, how many members have activity in the selected period, "
-            "and its active or quiet status. Teams with no activity in that period are listed first."
-        ),
-        "columns": [
-            ("team", "team"),
-            ("members", "members"),
-            ("active_members", "active"),
-            ("status", "status"),
-            ("days_since_active", "days since active"),
-            ("prs_opened", "PRs"),
-            ("reviews_given", "reviews"),
-            ("merges_done", "merges"),
-            ("issues_opened", "issues"),
-            ("labels_applied", "labels"),
-        ],
-    },
-    {
-        "id": "teamrepo",
-        "file": "team_activity_by_repo.csv",
-        "title": "Team activity by repo (all-time)",
-        "description": (
-            "Which repos each team is active in — type a team or repo to filter. This is a team-wide "
-            "rollup (headcount + totals per repo); for a named maintainer's own by-repo activity, see the "
-            "'Roles and recent activity by repo' table, and for individual TSC members, see the TSC table."
-        ),
-        "columns": [
-            ("team", "team"),
-            ("repo", "repo"),
-            ("members_active", "members active"),
-            ("prs_opened", "PRs"),
-            ("reviews_given", "reviews"),
-            ("merges_done", "merges"),
-            ("issues_opened", "issues"),
-            ("labels_applied", "labels"),
-            ("last_active", "last active"),
-        ],
-    },
 ]
 
-
-# Tables grouped by purpose so viewers get a short, scannable menu instead of one
-# long stack. Each group renders under its own heading (with a jump-bar link), and
-# within a group the order goes high-level aggregate → most granular. Groups render
-# after the charts. Order here is the on-screen order.
 SECTION_GROUPS = [
-    # The actionable headlines — where coverage is thin or work is concentrated.
-    ("Coverage & risk", ["repoactivity", "understaffed", "loadshare", "gonedark"]),
-    # Who is affiliated with which organisation, and how concentrated that is — the
-    # table companions to the Organisation-diversity charts.
-    ("Organisation diversity", ["affiliations", "repodiversity", "teamdiversity"]),
-    # Reference: who holds which role, per repo and per team.
-    ("Roles & teams", ["repo", "tscrepo", "teams", "teamrepo"]),
     # The full per-person list.
     ("All contributors", ["profiles"]),
 ]
 SECTION_ORDER = [sid for _name, ids in SECTION_GROUPS for sid in ids]
 SECTION_GROUP_OF = {sid: name for name, ids in SECTION_GROUPS for sid in ids}
 
-# Wide charts (vertical bars across many items): the dashboard scrolls these
-# horizontally at a readable height instead of squashing them to the card width.
-WIDE_CHARTS = {
-    "repo_affiliation_composition.png",
-    "repo_affiliation_composition_active.png",
-    "team_affiliation_composition.png",
-    "team_affiliation_composition_active.png",
-}
+WIDE_CHARTS: set[str] = set()
 
 # "How to read this" notes, keyed by chart filename. These describe how to read the
 # chart (its encoding and window) — never the current data values — so they stay
 # accurate across every refresh. A chart with no entry here simply shows no note.
 CHART_NOTES = {
-    "maintainer_pipeline_yearly.png": "Each bar is a calendar year, counting people active in its last six months (a fixed Jul–Dec "
-    "window for past years, so old bars stay put; a trailing six-month window for the current year). "
-    "Each person is counted once, under the highest governance role they hold in any repo "
-    "(general → triage → committer → maintainer), so the bar's total is the distinct people active.",
-    "maintainer_pipeline_monthly.png": "Each bar is a calendar month, counting the distinct people active that month — once each, under "
-    "the highest governance role they hold in any repo (general → triage → committer → maintainer). "
-    "Counts are strictly per-month (not a trailing window), so the current month is month-to-date. "
-    "Only the most recent 24 months are charted; full history stays in the CSV.",
-    "maintainer_pipeline_weekly.png": "Each bar is an ISO week (Mon–Sun), counting the distinct people active that week — once each, "
-    "under the highest governance role they hold in any repo (general → triage → committer → "
-    "maintainer). Counts are strictly per-week (not a trailing window), so the current week is "
-    "week-to-date. Only the most recent 26 weeks are charted; full history stays in the CSV.",
-    "maintainer_pipeline_by_repo.png": "Each bar is a repository, counting people active there in the last six months, grouped by the "
-    "governance role they hold in that repo (general → triage → committer → maintainer). A person "
-    "active in several repos is counted in each; smaller repos are pooled into 'Other Repos'.",
     "maintainer_network.png": "Each bubble is a repository, sized by how many maintainers are active in it; two repos are "
     "linked when they share a maintainer (thicker line = more shared). Bubble colour is the repo's "
     "category.",
@@ -487,30 +137,6 @@ CHART_NOTES = {
     "that month (issues ×2, reviews ×3, PRs opened ×3, merges ×2) — greener = more active. Aggregated "
     "straight from the events, so each counts once. The 25 busiest repositories are shown; bots are "
     "excluded.",
-    "affiliation_donut.png": "The share of maintainers held by the two largest employers, with everyone else (smaller orgs and "
-    "solo 'Independent' contributors) pooled into 'Other' — the concentration at a glance; the full "
-    "breakdown is in the affiliations table. Switch to the Active tab to count only maintainers active "
-    "in the last 90 days.",
-    "repo_affiliation_composition.png": "Each bar is a repository, normalised to 100% so the segments show each employer's share of that "
-    "repo's maintainers. The dashed line marks 50%: a segment reaching past it means one employer holds "
-    "the majority (an organisational bus-factor). Largest employers get their own colour, smaller ones "
-    "pool into 'Other orgs', and solo or unmapped maintainers show as 'Independent' and 'Unknown'. Repos "
-    "are ordered most-concentrated first — by the largest single employer's share — and repos with the "
-    "same concentration are grouped by their leading organisation (colour), so like sits next to like.",
-    "team_affiliation_composition.png": "Each bar is a governance team, normalised to 100% so the segments show each employer's share of the "
-    "team's members. The dashed line marks 50%: a segment past it means one employer holds the majority "
-    "(a capture / bus-factor risk). Largest employers get their own colour, smaller ones pool into "
-    "'Other orgs', and solo or unmapped members show as 'Independent' and 'Unknown'. Limited to teams "
-    "with at least four resolved members and ordered most-concentrated first; teams with the same "
-    "concentration are grouped by their leading organisation (colour). Every team is in the concentration table.",
-    "single_employer_teams_by_org.png": "Each bar is an organisation; bar height is how many governance teams it solely controls — every "
-    "resolved member of that team shares this one employer. Taller bars mean more single-employer "
-    "teams, a governance-capture / bus-factor risk. Teams are counted only where their members "
-    "resolve to an employer, so teams dominated by unmapped members are not over-counted here.",
-    "single_employer_repos_by_org.png": "Each bar is an organisation; bar height is how many repositories it solely maintains — every "
-    "resolved maintainer of that repo shares this one employer (at least two of them, no independents). "
-    "Taller bars mean more single-employer repos, an organisational bus-factor. Repos dominated by "
-    "unmapped maintainers are not counted here. The Active tab restricts to maintainers active in the last 90 days.",
     "contributor_counts.png": "The 20 repositories with the most distinct contributors over the last six months; bar height is "
     "the number of unique contributors.",
     "language_distribution.png": "How many repositories use each primary language (current snapshot). Repositories with no "
@@ -524,77 +150,6 @@ CHART_NOTES = {
 # notes these describe the method, never the current values, so they stay accurate.
 # A chart with no entry simply shows no methodology block.
 CHART_METHODOLOGY = {
-    "affiliation_donut.png": [
-        "Collect every maintainer from the governance config — anyone holding the maintainer role in any repo.",
-        "Look up each maintainer's organisation in the curated affiliations file.",
-        (
-            "That file resolves each person from public signals in priority order: GPG-key email, profile email, "
-            "the project MAINTAINERS.md, the GitHub company field, profile bio, public org membership, then "
-            "commit-author email. Obfuscated noreply addresses are ignored; Swirlds Labs counts as Hashgraph."
-        ),
-        (
-            "Count distinct maintainers per organisation; people with an identity but no employer are pooled as "
-            "'Independent'; people with no public signal are excluded."
-        ),
-        (
-            "Keep the two largest employers, fold everyone else (smaller orgs and independents) into 'Other', "
-            "and draw a filled pie of their shares."
-        ),
-    ],
-    "single_employer_teams_by_org.png": [
-        "Take every team in the governance config and list its members.",
-        "Map each member to an organisation via the affiliations file (same resolution as the other org charts).",
-        (
-            "Flag a team 'single-employer' when every member that resolves to an organisation shares the same one "
-            "(at least two such members, and no independents)."
-        ),
-        "Group those single-employer teams by the organisation that controls them.",
-        "Plot one bar per organisation — its height is how many teams it solely controls.",
-    ],
-    "single_employer_repos_by_org.png": [
-        "For each repository, take the maintainers holding the maintainer role there.",
-        "Map each to an organisation via the affiliations file (same resolution as the other org charts).",
-        (
-            "Flag a repo 'single-employer' when every resolved maintainer shares the same organisation "
-            "(at least two such maintainers, and no independents)."
-        ),
-        "Group those single-employer repos by the organisation that maintains them.",
-        "Plot one bar per organisation — its height is how many repos it solely maintains.",
-    ],
-    "repo_affiliation_composition.png": [
-        "For each repository, take the maintainers holding the maintainer role there.",
-        "Map each to an organisation via the affiliations file.",
-        (
-            "Count maintainers per organisation within the repo; the largest employers across all repos get their "
-            "own colour, the rest pool into 'Other orgs', and solo/unmapped maintainers show as "
-            "'Independent'/'Unknown'."
-        ),
-        (
-            "Normalise each repo's counts to 100% and stack them into one bar, ordered most-concentrated first "
-            "(by the largest single employer's share); ties are grouped by the leading organisation's colour."
-        ),
-        (
-            "A dashed line marks 50%: a segment past it means one employer holds the majority. Single-colour "
-            "bars are single-employer repos; multi-colour bars are cross-org."
-        ),
-    ],
-    "team_affiliation_composition.png": [
-        "For each governance team, take its members.",
-        "Map each member to an organisation via the affiliations file.",
-        (
-            "Count members per organisation (top employers coloured individually, the rest as 'Other orgs', plus "
-            "'Independent' and 'Unknown')."
-        ),
-        (
-            "Normalise each team's counts to 100% and stack into one bar, ordered most-concentrated first with "
-            "same-concentration teams grouped by their leading organisation's colour; only teams with at least "
-            "four resolved members are shown (the full set is in the team-concentration table)."
-        ),
-        (
-            "A dashed line marks 50%: a segment past it means one employer holds the majority. Single-colour "
-            "bars are employer-controlled teams; multi-colour bars are cross-org."
-        ),
-    ],
     "contributor_activity_heatmap.png": [
         (
             "Take every tracked event in the last six months — issues opened, PRs opened, reviews, merges — "

--- a/src/hiero_analytics/dashboard_spec/contributors.py
+++ b/src/hiero_analytics/dashboard_spec/contributors.py
@@ -13,20 +13,15 @@ CHART_MACRO = {
     "charts": {
         "hiero-ledger": [
             {
-                "id": "role-networks",
-                "title": "Activity networks by role",
-                "slideshow": True,
+                "id": "contributor-network",
+                "title": "Contributor network",
                 "description": (
-                    "Repositories linked by the people they share, one slide per group (all "
-                    "contributors first — the widest view — then maintainers, the smallest and most "
-                    "governance-relevant group). Each bubble is a repo sized by that group's active "
-                    "members; links mean shared members (thicker = more). Colour = repository type. "
-                    "Use Prev/Next; click to enlarge."
+                    "The widest view of how work connects the ecosystem: each bubble is a repository "
+                    "sized by its active contributors, and two repos are linked when they share "
+                    "contributors (thicker = more). Colour = repository type. Per-role versions "
+                    "(maintainers, committers, triage) live in the Governance tab. Click to enlarge."
                 ),
-                "files": [
-                    ("All contributors", "all_network.png"),
-                    ("Maintainers", "maintainer_network.png"),
-                ],
+                "files": [("Repositories linked by shared contributors", "all_network.png")],
             },
             {
                 "id": "activity-heatmap",
@@ -117,9 +112,6 @@ WIDE_CHARTS: set[str] = set()
 # chart (its encoding and window) — never the current data values — so they stay
 # accurate across every refresh. A chart with no entry here simply shows no note.
 CHART_NOTES = {
-    "maintainer_network.png": "Each bubble is a repository, sized by how many maintainers are active in it; two repos are "
-    "linked when they share a maintainer (thicker line = more shared). Bubble colour is the repo's "
-    "category.",
     "all_network.png": "Each bubble is a repository, sized by its active contributors; two repos are linked when they "
     "share contributors. Bubble colour is the repo's category; the link threshold scales with org size.",
     "contributor_activity_heatmap.png": "Rows are the 25 busiest contributors over the last six months; columns are those months. The "

--- a/src/hiero_analytics/dashboard_spec/governance.py
+++ b/src/hiero_analytics/dashboard_spec/governance.py
@@ -39,6 +39,24 @@ CHART_MACRO = {
                 ],
             },
             {
+                "id": "role-networks",
+                "title": "Role networks",
+                "slideshow": True,
+                "description": (
+                    "Repositories linked by the people who hold each governance role — one slide per "
+                    "tier, narrowing from maintainers (the most governance-relevant view) through "
+                    "committers to triage. Each bubble is a repo sized by that role's active holders; "
+                    "links mean shared holders (thicker = more). Colour = repository type. The "
+                    "all-contributors view lives in the Contributors tab. Use Prev/Next; click to "
+                    "enlarge."
+                ),
+                "files": [
+                    ("Maintainers", "maintainer_network.png"),
+                    ("Committers", "committer_network.png"),
+                    ("Triage", "triage_network.png"),
+                ],
+            },
+            {
                 "id": "org-diversity",
                 "title": "Organisation diversity",
                 "description": (
@@ -378,6 +396,15 @@ CHART_NOTES = {
     "maintainer_pipeline_by_repo.png": "Each bar is a repository, counting people active there in the last six months, grouped by the "
     "governance role they hold in that repo (general → triage → committer → maintainer). A person "
     "active in several repos is counted in each; smaller repos are pooled into 'Other Repos'.",
+    "maintainer_network.png": "Each bubble is a repository, sized by how many maintainers are active in it; two repos are "
+    "linked when they share a maintainer (thicker line = more shared). Bubble colour is the repo's "
+    "category.",
+    "committer_network.png": "Each bubble is a repository, sized by how many committers are active in it; two repos are "
+    "linked when they share a committer (thicker line = more shared). Bubble colour is the repo's "
+    "category.",
+    "triage_network.png": "Each bubble is a repository, sized by how many triage-role holders are active in it; two repos "
+    "are linked when they share a triage holder (thicker line = more shared). Bubble colour is the "
+    "repo's category.",
     "affiliation_donut.png": "The share of maintainers held by the two largest employers, with everyone else (smaller orgs and "
     "solo 'Independent' contributors) pooled into 'Other' — the concentration at a glance; the full "
     "breakdown is in the affiliations table. Switch to the Active tab to count only maintainers active "

--- a/src/hiero_analytics/dashboard_spec/governance.py
+++ b/src/hiero_analytics/dashboard_spec/governance.py
@@ -1,0 +1,483 @@
+"""Governance — authority, coverage, and concentration.
+
+The risk-focused family: who holds which role, where coverage is thin or
+quiet, how the maintainer pipeline is developing, and how concentrated
+authority is across employers. Pure data; see the package __init__ for
+assembly.
+"""
+
+from __future__ import annotations
+
+# "Suggest a correction" target for the affiliations reference table — the analytics
+# repo's issues page. The affiliations map is the source of truth, so a correction is
+# either a one-line edit to data/affiliations.yaml (append '# manual') or a new issue here.
+AFFILIATION_ISSUE_URL = "https://github.com/hiero-hackers/analytics/issues"
+
+CHART_MACRO = {
+    "name": "Governance",
+    "charts": {
+        "hiero-ledger": [
+            {
+                "id": "maintainer-pipeline",
+                "title": "Maintainer pipeline",
+                "description": (
+                    "How the maintainer/committer pipeline has moved over time and across repos — "
+                    "is the bench of future maintainers developing?"
+                ),
+                # One chart, four views: a tab switcher (By year / month / week / repo)
+                # shows a single chart at a time instead of stacking all four.
+                "files": [
+                    (
+                        "Unique active contributors by role",
+                        [
+                            ("By year", "maintainer_pipeline_yearly.png"),
+                            ("By month", "maintainer_pipeline_monthly.png"),
+                            ("By week", "maintainer_pipeline_weekly.png"),
+                            ("By repo", "maintainer_pipeline_by_repo.png"),
+                        ],
+                    ),
+                ],
+            },
+            {
+                "id": "org-diversity",
+                "title": "Organisation diversity",
+                "description": (
+                    "Where maintainer authority sits — org-wide, per team and per repo. The first chart is "
+                    "the ecosystem-wide split of maintainers by employer (solo contributors pooled as "
+                    "'Independent'); the next two count the governance teams and the repositories that a "
+                    "single employer solely controls (an organisational bus-factor); the last two break "
+                    "down each repository's and each team's maintainer mix. See the affiliations and "
+                    "repo-diversity tables below for the underlying detail."
+                ),
+                # Each chart offers an All / Active (last 90 days) tab so the roster
+                # and the day-to-day active core can be compared in place.
+                # The compact charts share the top rows; the two wide
+                # composition charts then stack full-width, one row each.
+                "files": [
+                    (
+                        "Maintainers by organisation",
+                        [
+                            ("All", "affiliation_donut.png"),
+                            ("Active 90d", "affiliation_donut_active.png"),
+                        ],
+                    ),
+                    (
+                        "Single-employer teams by org",
+                        [
+                            ("All", "single_employer_teams_by_org.png"),
+                            ("Active 90d", "single_employer_teams_by_org_active.png"),
+                        ],
+                    ),
+                    (
+                        "Single-employer repos by org",
+                        [
+                            ("All", "single_employer_repos_by_org.png"),
+                            ("Active 90d", "single_employer_repos_by_org_active.png"),
+                        ],
+                    ),
+                    (
+                        "Organisation mix by repo",
+                        [
+                            ("All", "repo_affiliation_composition.png"),
+                            ("Active 90d", "repo_affiliation_composition_active.png"),
+                        ],
+                    ),
+                    (
+                        "Organisation mix by team",
+                        [
+                            ("All", "team_affiliation_composition.png"),
+                            ("Active 90d", "team_affiliation_composition_active.png"),
+                        ],
+                    ),
+                ],
+            },
+        ],
+    },
+}
+
+# Each section: which CSV it reads and how to render it. Sections appear only when
+# their CSV exists and is non-empty, so governance-only tables are simply absent
+# for orgs without a governance config.
+SECTION_SPECS = [
+    {
+        "id": "repoactivity",
+        "file": "repo_activity_overview.csv",
+        "periods": True,
+        "title": "Repository activity — permission-holders by role",
+        "description": (
+            "One row per repo: how many maintainers, committers and triage hold it, how many "
+            "are active in the selected period, and activity split by role. Sorted by activity "
+            "within that period. 'actions' = PRs + reviews + merges + issues + labels, summed."
+        ),
+        "columns": [
+            ("repo", "repo"),
+            ("maintainers", "maintainers"),
+            ("committers", "committers"),
+            ("triage", "triage"),
+            ("active_recent", "active"),
+            ("maintainer_actions_recent", "maint. actions"),
+            ("committer_actions_recent", "comm. actions"),
+            ("triage_actions_recent", "triage actions"),
+            ("actions_recent", "actions"),
+            ("last_active", "last active"),
+        ],
+    },
+    {
+        "id": "understaffed",
+        "file": "maintainer_coverage_risk.csv",
+        "periods": True,
+        "title": "Repos with one or fewer active maintainers",
+        "description": (
+            "Repos where at most one maintainer has been active in the selected period. 'maintainers' is "
+            "the total on paper; 'committers' and 'triage' show others with access to the repo. Fewest "
+            "active maintainers first."
+        ),
+        "columns": [
+            ("repo", "repo"),
+            ("maintainers", "maintainers"),
+            ("active_maintainers", "active maintainers"),
+            ("committers", "committers"),
+            ("triage", "triage"),
+        ],
+    },
+    {
+        "id": "loadshare",
+        "file": "review_load_share.csv",
+        "periods": True,
+        "title": "Who carries the review load",
+        "description": (
+            "For each repo, the share of review+merge work in the selected period done by the single busiest "
+            "person who can merge — committer or maintainer. 'mergers' is how many reviewed/merged; "
+            "'top role' is whether the busiest is a committer or maintainer; 'top %' is their share, "
+            "'top-2 %' the top two combined. Highest concentration first; repos with under 20 recent "
+            "review+merge actions are omitted."
+        ),
+        "columns": [
+            ("repo", "repo"),
+            ("mergers", "mergers"),
+            ("load_recent", "review+merge"),
+            ("top_carrier", "top carrier"),
+            ("top_role", "top role"),
+            ("top_pct", "top %"),
+            ("top2_pct", "top-2 %"),
+        ],
+    },
+    {
+        "id": "repo",
+        "file": "role_coverage_all.csv",
+        "periods": True,
+        "title": "Roles and recent activity by repo",
+        "description": (
+            "Type a repo to see its permission-holders and their contributions in this repo "
+            "during the selected period, plus whether each has activity here in that period. "
+            "Days since active always refers to the latest recorded activity."
+        ),
+        "columns": [
+            ("repo", "repo"),
+            ("user", "user"),
+            ("granted_role", "role"),
+            ("status", "status"),
+            ("days_since_active", "days since active"),
+            ("prs_recent", "PRs"),
+            ("reviews_recent", "reviews"),
+            ("merges_recent", "merges"),
+            ("issues_recent", "issues"),
+            ("labels_recent", "labels"),
+        ],
+    },
+    {
+        "id": "affiliations",
+        "file": "maintainer_affiliations.csv",
+        "title": "Maintainer affiliations — reference",
+        "description": (
+            "Reference: each maintainer, the organisation they were mapped to, and how it was decided — "
+            "'automated' (the resolver placed them from public signals) or 'manual' (a hand-correction). "
+            "Status is 'affiliated' (named employer), 'independent' (solo / personal-email only), or "
+            "'unknown' (no public signal). To fix a mapping or resolve an unknown, edit its row in "
+            "data/affiliations.yaml and append '# manual: reason' (it then survives regeneration and reads "
+            "'manual' here), or use 'Suggest a correction' to open an issue on the analytics repo."
+        ),
+        "action_url": AFFILIATION_ISSUE_URL,
+        "action_label": "Suggest a correction",
+        "columns": [
+            ("login", "maintainer"),
+            ("organisation", "organisation"),
+            ("status", "status"),
+            ("method", "method"),
+        ],
+    },
+    {
+        "id": "repodiversity",
+        "file": "repo_affiliation_diversity.csv",
+        "title": "Maintainer organisation diversity by repo",
+        "description": (
+            "Per repo: how many maintainers it has, how many distinct employers they span, the largest "
+            "employer and its share of resolved (mapped) maintainers — the same definition as the team "
+            "table — and the independent / unknown counts. Repos where one employer holds every maintainer "
+            "seat ('distinct orgs' = 1) are an organisational bus-factor. Single-employer repos first."
+        ),
+        "columns": [
+            ("repo", "repo"),
+            ("maintainers", "maintainers"),
+            ("distinct_orgs", "distinct orgs"),
+            ("top_org", "largest org"),
+            ("top_org_pct", "largest org %"),
+            ("independent", "independent"),
+            ("unknown", "unknown"),
+            ("organisations", "organisations"),
+        ],
+    },
+    {
+        "id": "teamdiversity",
+        "file": "team_affiliation_diversity.csv",
+        "title": "Team organisation concentration",
+        "description": (
+            "Per governance team: how many members resolve to an employer, how many distinct employers "
+            "they span, the largest employer and its share, and the concentration (HHI, 10000 = one "
+            "employer). 'single employer' = one employer holds every resolved seat — a capture / "
+            "bus-factor risk, most serious for admin, release, security, and maintainer teams; teams with "
+            "more unmapped than resolved members are never flagged. 'unknown' "
+            "is how many members aren't in the affiliations map (mostly non-maintainers), so read a flag "
+            "on a mostly-unknown team with caution. Most concentrated first."
+        ),
+        "columns": [
+            ("team", "team"),
+            ("members", "members"),
+            ("resolved", "resolved"),
+            ("distinct_orgs", "distinct orgs"),
+            ("top_org", "largest org"),
+            ("top_org_pct", "largest org %"),
+            ("hhi", "HHI"),
+            ("unknown", "unknown"),
+            ("single_employer", "single employer"),
+            ("organisations", "organisation mix"),
+        ],
+    },
+    {
+        "id": "gonedark",
+        "file": "role_coverage_globally_quiet.csv",
+        "title": "Permission-holders with no recent activity (180+ days)",
+        "description": (
+            "Permission-holders with no recorded activity in any repo in the last 180 days. "
+            "Useful for keeping access lists current. A blank 'days since active' means no "
+            "recorded activity yet."
+        ),
+        "columns": [
+            ("user", "user"),
+            ("highest_role", "highest role"),
+            ("roles", "roles held"),
+            ("repos_held", "repos"),
+            ("days_since_active", "days since active"),
+            ("last_active", "last active"),
+        ],
+    },
+    {
+        "id": "tscrepo",
+        "file": "tsc_activity_by_repo.csv",
+        "title": "TSC activity by repo (all-time)",
+        "description": "For TSC members with activity, which repos they work in and the role they hold there.",
+        "columns": [
+            ("account", "member"),
+            ("repo", "repo"),
+            ("repo_role", "role here"),
+            ("prs_opened", "PRs"),
+            ("reviews_given", "reviews"),
+            ("merges_done", "merges"),
+            ("issues_opened", "issues"),
+            ("labels_applied", "labels"),
+            ("last_active", "last active"),
+        ],
+    },
+    {
+        "id": "teams",
+        "file": "team_activity_summary.csv",
+        "periods": True,
+        "title": "Team activity overview",
+        "description": (
+            "Each governance team's size, how many members have activity in the selected period, "
+            "and its active or quiet status. Teams with no activity in that period are listed first."
+        ),
+        "columns": [
+            ("team", "team"),
+            ("members", "members"),
+            ("active_members", "active"),
+            ("status", "status"),
+            ("days_since_active", "days since active"),
+            ("prs_opened", "PRs"),
+            ("reviews_given", "reviews"),
+            ("merges_done", "merges"),
+            ("issues_opened", "issues"),
+            ("labels_applied", "labels"),
+        ],
+    },
+    {
+        "id": "teamrepo",
+        "file": "team_activity_by_repo.csv",
+        "title": "Team activity by repo (all-time)",
+        "description": (
+            "Which repos each team is active in — type a team or repo to filter. This is a team-wide "
+            "rollup (headcount + totals per repo); for a named maintainer's own by-repo activity, see the "
+            "'Roles and recent activity by repo' table, and for individual TSC members, see the TSC table."
+        ),
+        "columns": [
+            ("team", "team"),
+            ("repo", "repo"),
+            ("members_active", "members active"),
+            ("prs_opened", "PRs"),
+            ("reviews_given", "reviews"),
+            ("merges_done", "merges"),
+            ("issues_opened", "issues"),
+            ("labels_applied", "labels"),
+            ("last_active", "last active"),
+        ],
+    },
+]
+
+
+# Tables grouped by purpose so viewers get a short, scannable menu instead of one
+# long stack. Each group renders under its own heading (with a jump-bar link), and
+# within a group the order goes high-level aggregate → most granular. Groups render
+# after the charts. Order here is the on-screen order.
+SECTION_GROUPS = [
+    # The actionable headlines — where coverage is thin or work is concentrated.
+    ("Coverage & risk", ["repoactivity", "understaffed", "loadshare", "gonedark"]),
+    # Who is affiliated with which organisation, and how concentrated that is — the
+    # table companions to the Organisation-diversity charts.
+    ("Organisation diversity", ["affiliations", "repodiversity", "teamdiversity"]),
+    # Reference: who holds which role, per repo and per team.
+    ("Roles & teams", ["repo", "tscrepo", "teams", "teamrepo"]),
+]
+SECTION_ORDER = [sid for _name, ids in SECTION_GROUPS for sid in ids]
+SECTION_GROUP_OF = {sid: name for name, ids in SECTION_GROUPS for sid in ids}
+
+# Wide charts (vertical bars across many items): the dashboard scrolls these
+# horizontally at a readable height instead of squashing them to the card width.
+WIDE_CHARTS = {
+    "repo_affiliation_composition.png",
+    "repo_affiliation_composition_active.png",
+    "team_affiliation_composition.png",
+    "team_affiliation_composition_active.png",
+}
+
+# "How to read this" notes, keyed by chart filename. These describe how to read the
+# chart (its encoding and window) — never the current data values — so they stay
+# accurate across every refresh. A chart with no entry here simply shows no note.
+CHART_NOTES = {
+    "maintainer_pipeline_yearly.png": "Each bar is a calendar year, counting people active in its last six months (a fixed Jul–Dec "
+    "window for past years, so old bars stay put; a trailing six-month window for the current year). "
+    "Each person is counted once, under the highest governance role they hold in any repo "
+    "(general → triage → committer → maintainer), so the bar's total is the distinct people active.",
+    "maintainer_pipeline_monthly.png": "Each bar is a calendar month, counting the distinct people active that month — once each, under "
+    "the highest governance role they hold in any repo (general → triage → committer → maintainer). "
+    "Counts are strictly per-month (not a trailing window), so the current month is month-to-date. "
+    "Only the most recent 24 months are charted; full history stays in the CSV.",
+    "maintainer_pipeline_weekly.png": "Each bar is an ISO week (Mon–Sun), counting the distinct people active that week — once each, "
+    "under the highest governance role they hold in any repo (general → triage → committer → "
+    "maintainer). Counts are strictly per-week (not a trailing window), so the current week is "
+    "week-to-date. Only the most recent 26 weeks are charted; full history stays in the CSV.",
+    "maintainer_pipeline_by_repo.png": "Each bar is a repository, counting people active there in the last six months, grouped by the "
+    "governance role they hold in that repo (general → triage → committer → maintainer). A person "
+    "active in several repos is counted in each; smaller repos are pooled into 'Other Repos'.",
+    "affiliation_donut.png": "The share of maintainers held by the two largest employers, with everyone else (smaller orgs and "
+    "solo 'Independent' contributors) pooled into 'Other' — the concentration at a glance; the full "
+    "breakdown is in the affiliations table. Switch to the Active tab to count only maintainers active "
+    "in the last 90 days.",
+    "repo_affiliation_composition.png": "Each bar is a repository, normalised to 100% so the segments show each employer's share of that "
+    "repo's maintainers. The dashed line marks 50%: a segment reaching past it means one employer holds "
+    "the majority (an organisational bus-factor). Largest employers get their own colour, smaller ones "
+    "pool into 'Other orgs', and solo or unmapped maintainers show as 'Independent' and 'Unknown'. Repos "
+    "are ordered most-concentrated first — by the largest single employer's share — and repos with the "
+    "same concentration are grouped by their leading organisation (colour), so like sits next to like.",
+    "team_affiliation_composition.png": "Each bar is a governance team, normalised to 100% so the segments show each employer's share of the "
+    "team's members. The dashed line marks 50%: a segment past it means one employer holds the majority "
+    "(a capture / bus-factor risk). Largest employers get their own colour, smaller ones pool into "
+    "'Other orgs', and solo or unmapped members show as 'Independent' and 'Unknown'. Limited to teams "
+    "with at least four resolved members and ordered most-concentrated first; teams with the same "
+    "concentration are grouped by their leading organisation (colour). Every team is in the concentration table.",
+    "single_employer_teams_by_org.png": "Each bar is an organisation; bar height is how many governance teams it solely controls — every "
+    "resolved member of that team shares this one employer. Taller bars mean more single-employer "
+    "teams, a governance-capture / bus-factor risk. Teams are counted only where their members "
+    "resolve to an employer, so teams dominated by unmapped members are not over-counted here.",
+    "single_employer_repos_by_org.png": "Each bar is an organisation; bar height is how many repositories it solely maintains — every "
+    "resolved maintainer of that repo shares this one employer (at least two of them, no independents). "
+    "Taller bars mean more single-employer repos, an organisational bus-factor. Repos dominated by "
+    "unmapped maintainers are not counted here. The Active tab restricts to maintainers active in the last 90 days.",
+}
+
+# Step-by-step "how this was built" methodology, keyed by chart filename. Shown as
+# an expandable list in the zoom (lightbox) view, under the short note. Like the
+# notes these describe the method, never the current values, so they stay accurate.
+# A chart with no entry simply shows no methodology block.
+CHART_METHODOLOGY = {
+    "affiliation_donut.png": [
+        "Collect every maintainer from the governance config — anyone holding the maintainer role in any repo.",
+        "Look up each maintainer's organisation in the curated affiliations file.",
+        (
+            "That file resolves each person from public signals in priority order: GPG-key email, profile email, "
+            "the project MAINTAINERS.md, the GitHub company field, profile bio, public org membership, then "
+            "commit-author email. Obfuscated noreply addresses are ignored; Swirlds Labs counts as Hashgraph."
+        ),
+        (
+            "Count distinct maintainers per organisation; people with an identity but no employer are pooled as "
+            "'Independent'; people with no public signal are excluded."
+        ),
+        (
+            "Keep the two largest employers, fold everyone else (smaller orgs and independents) into 'Other', "
+            "and draw a filled pie of their shares."
+        ),
+    ],
+    "single_employer_teams_by_org.png": [
+        "Take every team in the governance config and list its members.",
+        "Map each member to an organisation via the affiliations file (same resolution as the other org charts).",
+        (
+            "Flag a team 'single-employer' when every member that resolves to an organisation shares the same one "
+            "(at least two such members, and no independents)."
+        ),
+        "Group those single-employer teams by the organisation that controls them.",
+        "Plot one bar per organisation — its height is how many teams it solely controls.",
+    ],
+    "single_employer_repos_by_org.png": [
+        "For each repository, take the maintainers holding the maintainer role there.",
+        "Map each to an organisation via the affiliations file (same resolution as the other org charts).",
+        (
+            "Flag a repo 'single-employer' when every resolved maintainer shares the same organisation "
+            "(at least two such maintainers, and no independents)."
+        ),
+        "Group those single-employer repos by the organisation that maintains them.",
+        "Plot one bar per organisation — its height is how many repos it solely maintains.",
+    ],
+    "repo_affiliation_composition.png": [
+        "For each repository, take the maintainers holding the maintainer role there.",
+        "Map each to an organisation via the affiliations file.",
+        (
+            "Count maintainers per organisation within the repo; the largest employers across all repos get their "
+            "own colour, the rest pool into 'Other orgs', and solo/unmapped maintainers show as "
+            "'Independent'/'Unknown'."
+        ),
+        (
+            "Normalise each repo's counts to 100% and stack them into one bar, ordered most-concentrated first "
+            "(by the largest single employer's share); ties are grouped by the leading organisation's colour."
+        ),
+        (
+            "A dashed line marks 50%: a segment past it means one employer holds the majority. Single-colour "
+            "bars are single-employer repos; multi-colour bars are cross-org."
+        ),
+    ],
+    "team_affiliation_composition.png": [
+        "For each governance team, take its members.",
+        "Map each member to an organisation via the affiliations file.",
+        (
+            "Count members per organisation (top employers coloured individually, the rest as 'Other orgs', plus "
+            "'Independent' and 'Unknown')."
+        ),
+        (
+            "Normalise each team's counts to 100% and stack into one bar, ordered most-concentrated first with "
+            "same-concentration teams grouped by their leading organisation's colour; only teams with at least "
+            "four resolved members are shown (the full set is in the team-concentration table)."
+        ),
+        (
+            "A dashed line marks 50%: a segment past it means one employer holds the majority. Single-colour "
+            "bars are employer-controlled teams; multi-colour bars are cross-org."
+        ),
+    ],
+}

--- a/src/hiero_analytics/export/assets/dashboard.css
+++ b/src/hiero_analytics/export/assets/dashboard.css
@@ -5,7 +5,7 @@ h1{font-size:22px;font-weight:600;margin:0 0 4px}
 .metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin-bottom:24px}
 .metric{background:#fff;border:1px solid #e6e6e6;border-radius:10px;padding:14px 16px}
 .macrobar{display:flex;gap:8px;margin-bottom:16px;flex-wrap:wrap}
-.macro{padding:9px 18px;border:1px solid #ddd;background:#fff;border-radius:999px;cursor:pointer;font-size:14px;font-weight:600;color:#444}
+.macro{padding:9px 18px;border:1px solid #ddd;background:#fff;border-radius:999px;cursor:pointer;font-size:14px;font-weight:600;color:#444;text-decoration:none;display:inline-block}
 .macro.active{background:#1b1b1b;color:#fff;border-color:#1b1b1b}
 .macro:hover{border-color:#999}
 .tabbar{display:flex;gap:6px;margin-bottom:18px;border-bottom:1px solid #e0e0e0;flex-wrap:wrap}

--- a/src/hiero_analytics/export/assets/dashboard.js
+++ b/src/hiero_analytics/export/assets/dashboard.js
@@ -4,6 +4,13 @@ function sortTable(id,col,th){var tb=document.querySelector('#'+id+' tbody');var
 function csvCell(s){s=(s==null?'':String(s)).trim();return /[",\n]/.test(s)?'"'+s.replace(/"/g,'""')+'"':s;}
 function exportCSV(id,name){var out=[];var ths=document.querySelectorAll('#'+id+' thead th');out.push([].map.call(ths,function(th){return csvCell(th.textContent);}).join(','));document.querySelectorAll('#'+id+' tbody tr').forEach(function(tr){if(tr.style.display==='none')return;out.push([].map.call(tr.children,function(td){return csvCell(td.textContent);}).join(','));});var blob=new Blob([out.join('\n')],{type:'text/csv'});var a=document.createElement('a');a.href=URL.createObjectURL(blob);a.download=name;document.body.appendChild(a);a.click();document.body.removeChild(a);URL.revokeObjectURL(a.href);}
 function switchMacro(m){document.querySelectorAll('.macropanel').forEach(function(p){p.style.display='none';});document.getElementById('macro-'+m).style.display='';document.querySelectorAll('.macro').forEach(function(b){b.classList.remove('active');});document.getElementById('macrobtn-'+m).classList.add('active');}
+/* The macro tabs are real links (#contributors, #governance, ...): the hash is
+   the source of truth, so tabs are shareable and back/forward work. Hashes that
+   don't name a macro panel (e.g. the jump-bar's section anchors) are left to
+   native anchor behaviour. */
+function applyMacroHash(){var slug=location.hash.replace(/^#/,'');if(document.getElementById('macro-'+slug))switchMacro(slug);}
+window.addEventListener('hashchange',applyMacroHash);
+applyMacroHash();
 function switchTab(m,o){var panel=document.getElementById('macro-'+m);panel.querySelectorAll('.tabpanel').forEach(function(p){p.style.display='none';});document.getElementById('tab-'+m+'-'+o).style.display='';panel.querySelectorAll('.tab').forEach(function(b){b.classList.remove('active');});document.getElementById('tabbtn-'+m+'-'+o).classList.add('active');}
 function openLightbox(el){var src=(typeof el==='string')?el:el.src;document.getElementById('lightbox-img').src=src;var info='';if(el&&el.closest){var fig=el.closest('figure');if(fig){var di=el.getAttribute?el.getAttribute('data-i'):null;var n=(di!=null)?fig.querySelector(".lbinfo[data-i='"+di+"']"):null;if(!n)n=fig.querySelector('.lbinfo:not([data-i])');if(n)info=n.innerHTML;}}document.getElementById('lightbox-note').innerHTML=info;document.getElementById('lightbox').style.display='flex';}
 function closeLightbox(){var lb=document.getElementById('lightbox');lb.style.display='none';document.getElementById('lightbox-img').src='';document.getElementById('lightbox-note').innerHTML='';}

--- a/src/hiero_analytics/export/dashboard.py
+++ b/src/hiero_analytics/export/dashboard.py
@@ -296,8 +296,8 @@ def build_dashboard_html(macros: Sequence[Mapping], *, generated_at: str | None 
     macro_bar = ""
     if macros:  # macro bar always shows (even at one family), so the scope is labelled
         buttons = "".join(
-            f"<button class='macro{' active' if i == 0 else ''}' id='macrobtn-{_slug(macro['name'])}' "
-            f"onclick=\"switchMacro('{_slug(macro['name'])}')\">{esc(macro['name'])}</button>"
+            f"<a class='macro{' active' if i == 0 else ''}' id='macrobtn-{_slug(macro['name'])}' "
+            f"href='#{_slug(macro['name'])}'>{esc(macro['name'])}</a>"
             for i, macro in enumerate(macros)
         )
         macro_bar = f"<div class='macrobar'>{buttons}</div>"

--- a/src/hiero_analytics/pipelines/contributor_activity.py
+++ b/src/hiero_analytics/pipelines/contributor_activity.py
@@ -15,14 +15,18 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime, timedelta
 
+import pandas as pd
+
 from hiero_analytics.analysis.comembership import build_comembership_network
 from hiero_analytics.analysis.contributor_activity_profile import (
     build_active_membership,
     build_contributor_profiles,
     build_contributor_profiles_by_repo,
 )
+from hiero_analytics.analysis.prs import filter_gfi_prs, prs_to_dataframe
 from hiero_analytics.config.analysis import CONTRIBUTOR_NETWORK_REPOS_PER_LINK, ROLE_ACTIVE_DAYS
 from hiero_analytics.config.paths import ORG, ensure_repo_dirs
+from hiero_analytics.data_sources.github_ingest import fetch_org_merged_pr_difficulty_graphql
 from hiero_analytics.domain.periods import ACTIVITY_PERIODS
 from hiero_analytics.export.save import save_dataframe
 from hiero_analytics.pipelines._shared import load_contributor_activity, load_issue_label_events, org_context
@@ -57,6 +61,19 @@ def _build_contributor_network(records, label_events, by_repo, org_charts_dir, o
         logger.info("Contributor network: %d repos, %d links (shared>=%d)", len(nodes), len(edges), min_shared)
 
 
+def _write_gfi_completers(client, org: str, org_data_dir) -> None:
+    """Distinct contributors with a merged PR that closed an onboarding (GFI) issue.
+
+    Feeds the Contributors tab's "completed a GFI %" tile. Backed by the org
+    merged-PR dataset (incremental; offline-capable once the dataset is cached).
+    """
+    prs = fetch_org_merged_pr_difficulty_graphql(client, org)
+    gfi = filter_gfi_prs(prs_to_dataframe(prs))
+    logins = sorted(gfi.dropna(subset=["author"])["author"].str.lower().unique())
+    save_dataframe(pd.DataFrame({"login": logins}), org_data_dir / "gfi_completers.csv")
+    logger.info("GFI completers: %d contributors", len(logins))
+
+
 def main(org: str = ORG) -> None:
     """Build the informational contributor-activity tables for an org.
 
@@ -72,6 +89,8 @@ def main(org: str = ORG) -> None:
     records = load_contributor_activity(client, org)
     label_events = load_issue_label_events(client, org)
     logger.info("Using %d activity records and %d label events (all-time)", len(records), len(label_events))
+
+    _write_gfi_completers(client, org, org_data_dir)
 
     # Org-wide: one row per contributor, emitted once for each shared activity period.
     now = datetime.now(UTC)

--- a/src/hiero_analytics/pipelines/contributor_activity.py
+++ b/src/hiero_analytics/pipelines/contributor_activity.py
@@ -26,6 +26,7 @@ from hiero_analytics.analysis.contributor_activity_profile import (
 from hiero_analytics.analysis.prs import filter_gfi_prs, prs_to_dataframe
 from hiero_analytics.config.analysis import CONTRIBUTOR_NETWORK_REPOS_PER_LINK, ROLE_ACTIVE_DAYS
 from hiero_analytics.config.paths import ORG, ensure_repo_dirs
+from hiero_analytics.data_sources.dataset_store import OfflineDatasetMissingError
 from hiero_analytics.data_sources.github_ingest import fetch_org_merged_pr_difficulty_graphql
 from hiero_analytics.domain.periods import ACTIVITY_PERIODS
 from hiero_analytics.export.save import save_dataframe
@@ -66,8 +67,15 @@ def _write_gfi_completers(client, org: str, org_data_dir) -> None:
 
     Feeds the Contributors tab's "completed a GFI %" tile. Backed by the org
     merged-PR dataset (incremental; offline-capable once the dataset is cached).
+    The tile is optional: an offline run without the cached dataset skips it
+    (the dashboard tolerates a missing gfi_completers.csv) rather than failing
+    the whole pipeline.
     """
-    prs = fetch_org_merged_pr_difficulty_graphql(client, org)
+    try:
+        prs = fetch_org_merged_pr_difficulty_graphql(client, org)
+    except OfflineDatasetMissingError:
+        logger.warning("No cached merged-PR dataset for %s in offline mode; skipping GFI completers", org)
+        return
     gfi = filter_gfi_prs(prs_to_dataframe(prs))
     logins = sorted(gfi.dropna(subset=["author"])["author"].str.lower().unique())
     save_dataframe(pd.DataFrame({"login": logins}), org_data_dir / "gfi_completers.csv")

--- a/src/hiero_analytics/pipelines/dashboard.py
+++ b/src/hiero_analytics/pipelines/dashboard.py
@@ -166,12 +166,35 @@ def _chart_sections(org: str, chart_specs: list[dict]) -> list[dict]:
     return sections
 
 
-def _contributors_metrics(loaded: dict[str, pd.DataFrame]) -> list:
-    """Headline tiles for the Contributors macro."""
-    return [("contributors", len(loaded["profiles"]))] if not loaded["profiles"].empty else []
+def _pct(count: int, total: int) -> str:
+    """A whole-number percentage tile value ("37%")."""
+    return f"{round(100 * count / total)}%"
 
 
-def _governance_metrics(loaded: dict[str, pd.DataFrame]) -> list:
+def _contributors_metrics(loaded: dict[str, pd.DataFrame], org_data_dir: Path) -> list:
+    """Headline tiles for the Contributors macro: who shows up, and how.
+
+    All shares are over the full contributor list (the profiles table). "% commit"
+    is measured as opening PRs — commits themselves aren't ingested.
+    """
+    profiles = loaded["profiles"]
+    total = len(profiles)
+    if total == 0:
+        return []
+    metrics = [
+        ("contributors", total),
+        ("multi-repo %", _pct(int((profiles["repos_touched"] >= 2).sum()), total)),
+        ("file issues %", _pct(int((profiles["issues_opened"] > 0).sum()), total)),
+        ("open PRs %", _pct(int((profiles["prs_opened"] > 0).sum()), total)),
+        ("give reviews %", _pct(int((profiles["reviews_given"] > 0).sum()), total)),
+    ]
+    completers = _load(org_data_dir / "gfi_completers.csv")
+    if "login" in completers:
+        metrics.append(("completed a GFI %", _pct(int(completers["login"].nunique()), total)))
+    return metrics
+
+
+def _governance_metrics(loaded: dict[str, pd.DataFrame], _org_data_dir: Path) -> list:
     """Headline tiles for the Governance macro."""
     metrics: list = []
     role_counts = _holders_by_highest_role(loaded["repo"])
@@ -241,7 +264,7 @@ def _org_table_tab(family: ModuleType, org_name: str, org_data_dir: Path) -> dic
     if not sections:
         return None  # this org has no data for this family
     metrics_builder = _METRICS_BY_MACRO.get(family.CHART_MACRO["name"])
-    metrics = metrics_builder(loaded) if metrics_builder is not None else []
+    metrics = metrics_builder(loaded, org_data_dir) if metrics_builder is not None else []
     return {"org": org_name, "metrics": metrics, "sections": sections}
 
 

--- a/src/hiero_analytics/pipelines/dashboard.py
+++ b/src/hiero_analytics/pipelines/dashboard.py
@@ -183,6 +183,15 @@ def _contributors_metrics(loaded: dict[str, pd.DataFrame], org_data_dir: Path) -
         return []
     metrics = [
         ("contributors", total),
+    ]
+    # "Active last month": the 30d period variant lists exactly the contributors
+    # with activity in that window, so the share is a row-count ratio.
+    month = next((p for p in ACTIVITY_PERIODS if p.key == "30d"), None)
+    if month is not None:
+        active = _load(org_data_dir / month.filename("contributor_activity_profiles"))
+        if not active.empty:
+            metrics.append(("active last month %", _pct(len(active), total)))
+    metrics += [
         ("multi-repo %", _pct(int((profiles["repos_touched"] >= 2).sum()), total)),
         ("file issues %", _pct(int((profiles["issues_opened"] > 0).sum()), total)),
         ("open PRs %", _pct(int((profiles["prs_opened"] > 0).sum()), total)),

--- a/src/hiero_analytics/pipelines/dashboard.py
+++ b/src/hiero_analytics/pipelines/dashboard.py
@@ -15,6 +15,7 @@ import json
 import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import ModuleType
 
 import pandas as pd
 
@@ -24,10 +25,7 @@ from hiero_analytics.dashboard_spec import (
     CHART_METHODOLOGY,
     CHART_NOTES,
     CHARTS_GROUP,
-    MACRO_NAME,
-    SECTION_GROUP_OF,
-    SECTION_ORDER,
-    SECTION_SPECS,
+    TABLE_FAMILIES,
     WIDE_CHARTS,
 )
 from hiero_analytics.domain.periods import ACTIVITY_PERIODS, DEFAULT_ACTIVITY_PERIOD
@@ -168,19 +166,38 @@ def _chart_sections(org: str, chart_specs: list[dict]) -> list[dict]:
     return sections
 
 
-def _org_tab(org_name: str, org_data_dir: Path) -> dict | None:
-    """Build one org's tab from whatever CSVs it has, or None if it has no data."""
-    loaded = {spec["id"]: _load(org_data_dir / spec["file"]) for spec in SECTION_SPECS}
-    period_variants = {
-        spec["id"]: _load_period_variants(spec, org_data_dir) for spec in SECTION_SPECS if spec.get("periods")
-    }
-    if loaded["profiles"].empty:
-        return None  # no core contributor data for this org
+def _contributors_metrics(loaded: dict[str, pd.DataFrame]) -> list:
+    """Headline tiles for the Contributors macro."""
+    return [("contributors", len(loaded["profiles"]))] if not loaded["profiles"].empty else []
 
-    # High-level → individual order (see SECTION_ORDER), non-empty tables only.
-    specs_by_id = {spec["id"]: spec for spec in SECTION_SPECS}
+
+def _governance_metrics(loaded: dict[str, pd.DataFrame]) -> list:
+    """Headline tiles for the Governance macro."""
+    metrics: list = []
+    role_counts = _holders_by_highest_role(loaded["repo"])
+    for role, label in (("maintainer", "maintainers"), ("committer", "committers"), ("triage", "triage")):
+        if role in role_counts:
+            metrics.append((label, role_counts[role]))
+    if not loaded["gonedark"].empty:
+        metrics.append(("quiet permission-holders (180d+)", len(loaded["gonedark"])))
+    if "status" in loaded["teams"]:
+        metrics.append(("quiet teams", int((loaded["teams"]["status"] == "quiet").sum())))
+    return metrics
+
+
+_METRICS_BY_MACRO = {"Contributors": _contributors_metrics, "Governance": _governance_metrics}
+
+
+def _org_table_tab(family: ModuleType, org_name: str, org_data_dir: Path) -> dict | None:
+    """Build one family's table tab for an org, or None if it has no data."""
+    specs = family.SECTION_SPECS
+    loaded = {spec["id"]: _load(org_data_dir / spec["file"]) for spec in specs}
+    period_variants = {spec["id"]: _load_period_variants(spec, org_data_dir) for spec in specs if spec.get("periods")}
+
+    # High-level → individual order (see the family's SECTION_ORDER), non-empty tables only.
+    specs_by_id = {spec["id"]: spec for spec in specs}
     sections = []
-    for section_id in SECTION_ORDER:
+    for section_id in family.SECTION_ORDER:
         spec = specs_by_id[section_id]
         variants = period_variants.get(section_id, [])
         if loaded[section_id].empty and not variants:
@@ -189,7 +206,7 @@ def _org_tab(org_name: str, org_data_dir: Path) -> dict | None:
             "id": spec["id"],
             "title": spec["title"],
             "description": spec["description"],
-            "group": SECTION_GROUP_OF[section_id],
+            "group": family.SECTION_GROUP_OF[section_id],
             # Optional "Suggest a correction" action link (e.g. the affiliations table).
             **({"action_url": spec["action_url"]} if spec.get("action_url") else {}),
             **({"action_label": spec["action_label"]} if spec.get("action_label") else {}),
@@ -221,16 +238,10 @@ def _org_tab(org_name: str, org_data_dir: Path) -> dict | None:
             section["rows"] = loaded[section_id].to_dict("records")
         sections.append(section)
 
-    metrics = [("contributors", len(loaded["profiles"]))]
-    role_counts = _holders_by_highest_role(loaded["repo"])
-    for role, label in (("maintainer", "maintainers"), ("committer", "committers"), ("triage", "triage")):
-        if role in role_counts:
-            metrics.append((label, role_counts[role]))
-    if not loaded["gonedark"].empty:
-        metrics.append(("quiet permission-holders (180d+)", len(loaded["gonedark"])))
-    if "status" in loaded["teams"]:
-        metrics.append(("quiet teams", int((loaded["teams"]["status"] == "quiet").sum())))
-
+    if not sections:
+        return None  # this org has no data for this family
+    metrics_builder = _METRICS_BY_MACRO.get(family.CHART_MACRO["name"])
+    metrics = metrics_builder(loaded) if metrics_builder is not None else []
     return {"org": org_name, "metrics": metrics, "sections": sections}
 
 
@@ -249,18 +260,16 @@ def main() -> None:
     ORG_DATA_DIR.mkdir(parents=True, exist_ok=True)
 
     orgs = _ordered_orgs()
-    table_tabs = {org: tab for org in orgs if (tab := _org_tab(org, ORG_DATA_DIR / org)) is not None}
 
     macros = []
     for macro in CHART_MACROS:
-        is_tables_macro = macro["name"] == MACRO_NAME
+        # A family with table sections renders them inside its own macro.
+        family = TABLE_FAMILIES.get(macro["name"])
         org_tabs = []
         for org in orgs:
-            table_sections: list[dict] = []
-            metrics: list = []
-            if is_tables_macro and org in table_tabs:
-                table_sections = list(table_tabs[org]["sections"])
-                metrics = table_tabs[org]["metrics"]
+            table_tab = _org_table_tab(family, org, ORG_DATA_DIR / org) if family is not None else None
+            table_sections = list(table_tab["sections"]) if table_tab is not None else []
+            metrics = table_tab["metrics"] if table_tab is not None else []
             # Charts first, then tables (high-level → individual within the tables).
             sections = _chart_sections(org, macro["charts"].get(org, [])) + table_sections
             if sections:

--- a/src/hiero_analytics/pipelines/role_coverage.py
+++ b/src/hiero_analytics/pipelines/role_coverage.py
@@ -163,15 +163,17 @@ def _write_repo_summaries(combined, org_data_dir, period: Period | None = None):
 
 
 def _write_role_networks(combined, org_charts_dir, org: str = ORG):
-    """Maintainer co-membership network.
+    """Co-membership networks per governance role (maintainer, committer, triage).
 
-    The most governance-relevant of the role networks — kept alongside the
-    all-contributors network (governance-independent, produced by
-    run_contributor_activity_org for every org) so the dashboard shows the
-    narrowest and widest view without maintaining every role's network chart.
+    The Governance tab shows how each permission tier connects the repos; the
+    all-contributors network (governance-independent, produced by the
+    contributor_activity pipeline for every org) stays the Contributors tab's
+    widest view. A role no repo grants simply renders no chart.
     """
     groups = [
         ("maintainer", "maintainers", role_membership(combined, "maintainer"), ROLE_NETWORK_MIN_SHARED["maintainer"]),
+        ("committer", "committers", role_membership(combined, "committer"), ROLE_NETWORK_MIN_SHARED["committer"]),
+        ("triage", "triage holders", role_membership(combined, "triage"), ROLE_NETWORK_MIN_SHARED["triage"]),
     ]
     for key, label, membership, min_shared in groups:
         nodes, edges = build_comembership_network(membership, min_shared=min_shared)

--- a/tests/contracts/test_output_contract.py
+++ b/tests/contracts/test_output_contract.py
@@ -40,7 +40,7 @@ import hiero_analytics.pipelines.onboarding as onboarding_mod
 import hiero_analytics.pipelines.role_coverage as role_coverage_mod
 import hiero_analytics.pipelines.run_all as run_all
 import hiero_analytics.pipelines.scorecard as scorecard_mod
-from hiero_analytics.dashboard_spec import CHART_MACROS, SECTION_SPECS
+from hiero_analytics.dashboard_spec import CHART_MACROS, TABLE_FAMILIES
 from hiero_analytics.data_sources.models import (
     CodeOwnersRecord,
     ContributorActivityRecord,
@@ -52,6 +52,9 @@ from hiero_analytics.data_sources.models import (
     ScorecardRecord,
 )
 from hiero_analytics.domain.periods import ACTIVITY_PERIODS
+
+# Every table section across the table-bearing macros (Contributors, Governance).
+ALL_SECTION_SPECS = [spec for family in TABLE_FAMILIES.values() for spec in family.SECTION_SPECS]
 
 PRIMARY = "hiero-ledger"
 HACKERS = "hiero-hackers"
@@ -333,7 +336,7 @@ def test_every_spec_table_csv_is_produced(outputs_root: Path):
     """Each section's CSV (and every derived period variant) exists for the primary org."""
     org_data = outputs_root / "data" / "org" / PRIMARY
     missing = []
-    for spec in SECTION_SPECS:
+    for spec in ALL_SECTION_SPECS:
         expected = [spec["file"]]
         if spec.get("periods"):
             stem = Path(spec["file"]).stem
@@ -357,7 +360,7 @@ def test_every_spec_chart_png_is_produced(outputs_root: Path):
 def test_no_orphan_org_level_outputs(outputs_root: Path):
     """Everything produced at org level is spec-listed or explicitly accounted for."""
     spec_csvs = set()
-    for spec in SECTION_SPECS:
+    for spec in ALL_SECTION_SPECS:
         spec_csvs.add(spec["file"])
         if spec.get("periods"):
             stem = Path(spec["file"]).stem
@@ -388,7 +391,8 @@ def test_no_orphan_org_level_outputs(outputs_root: Path):
 
 
 def test_dashboard_html_is_written(outputs_root: Path):
-    """The assembled dashboard exists and carries the macro tabs."""
+    """The assembled dashboard exists and carries both table-bearing macro tabs."""
     html = (outputs_root / "dashboard.html").read_text(encoding="utf-8")
-    assert "Contributors &amp; governance" in html or "Contributors & governance" in html
+    assert ">Contributors<" in html  # the people/activity macro button
+    assert ">Governance<" in html  # the authority/risk macro button
     assert len(html) > 10_000

--- a/tests/contracts/test_output_contract.py
+++ b/tests/contracts/test_output_contract.py
@@ -88,6 +88,7 @@ CHART_COMPANION_CSVS = {
     "difficulty_by_repo_30_days.csv",
     "difficulty_over_time_event_based_weekly.csv",
     "maintainer_activity_events.csv",
+    "gfi_completers.csv",  # Contributors-tab KPI tile source (completed-a-GFI %)
     "maintainer_pipeline_yearly.csv",
     "maintainer_pipeline_monthly.csv",
     "maintainer_pipeline_weekly.csv",
@@ -270,6 +271,7 @@ def outputs_root(tmp_path_factory) -> Path:
         mp.setattr(onboarding_mod, "fetch_repo_issues_graphql", lambda _c, **_k: REPO_ISSUES)
         mp.setattr(onboarding_mod, "fetch_repo_merged_pr_difficulty_graphql", lambda _c, **_k: REPO_PRS)
         mp.setattr(profiles_mod, "fetch_repo_merged_pr_difficulty_graphql", lambda _c, **_k: REPO_PRS)
+        mp.setattr(activity_mod, "fetch_org_merged_pr_difficulty_graphql", lambda _c, _org, **_k: REPO_PRS)
         for mod in (maintainer_mod, heatmap_mod, role_coverage_mod, affiliation_mod):
             mp.setattr(mod, "fetch_governance_config", lambda *_a, **_k: GOVERNANCE)
         for mod in (maintainer_mod, heatmap_mod, role_coverage_mod, affiliation_mod, activity_mod):

--- a/tests/contracts/test_output_contract.py
+++ b/tests/contracts/test_output_contract.py
@@ -195,10 +195,17 @@ GOVERNANCE = {
         # Five resolved, recently active members so the team-composition charts
         # (which need >= 4 resolved members) render in both All and Active views.
         {"name": "core", "maintainers": [], "members": ["alice", "bob", "carol", "dave", "erin"]},
+        # Write- and triage-permission teams so the committer and triage role
+        # networks (Governance tab) have holders to render.
+        {"name": "sdk-devs", "maintainers": [], "members": ["bob", "dave"]},
+        {"name": "triagers", "maintainers": [], "members": ["erin"]},
     ],
     "repositories": [
-        {"name": "sdk-python", "teams": {"sdk-python-maintainers": "maintain"}},
-        {"name": "sdk-java", "teams": {"sdk-java-maintainers": "maintain"}},
+        {
+            "name": "sdk-python",
+            "teams": {"sdk-python-maintainers": "maintain", "sdk-devs": "write", "triagers": "triage"},
+        },
+        {"name": "sdk-java", "teams": {"sdk-java-maintainers": "maintain", "sdk-devs": "write"}},
     ],
 }
 

--- a/tests/dashboard_spec/test_spec_consistency.py
+++ b/tests/dashboard_spec/test_spec_consistency.py
@@ -6,8 +6,7 @@ from hiero_analytics.dashboard_spec import (
     CHART_MACROS,
     CHART_METHODOLOGY,
     CHART_NOTES,
-    SECTION_GROUPS,
-    SECTION_SPECS,
+    TABLE_FAMILIES,
     WIDE_CHARTS,
 )
 
@@ -41,11 +40,12 @@ def test_section_groups_match_section_specs():
 
     A drifted id would otherwise only surface as a KeyError mid-dashboard-build.
     """
-    spec_ids = [spec["id"] for spec in SECTION_SPECS]
-    grouped_ids = [section_id for _name, ids in SECTION_GROUPS for section_id in ids]
+    for macro_name, family in TABLE_FAMILIES.items():
+        spec_ids = [spec["id"] for spec in family.SECTION_SPECS]
+        grouped_ids = [section_id for _name, ids in family.SECTION_GROUPS for section_id in ids]
 
-    assert len(set(spec_ids)) == len(spec_ids)  # no duplicate section ids
-    assert sorted(grouped_ids) == sorted(spec_ids)
+        assert len(set(spec_ids)) == len(spec_ids), macro_name  # no duplicate section ids
+        assert sorted(grouped_ids) == sorted(spec_ids), macro_name
 
 
 def test_chart_files_are_canonical():

--- a/tests/export/test_dashboard.py
+++ b/tests/export/test_dashboard.py
@@ -84,9 +84,9 @@ def test_macro_bar_shows_even_for_one_family_and_scales_up():
     )
 
     assert "class='macrobar'" in one  # shown even with a single family
-    assert "switchMacro('governance')" in one
+    assert "href='#governance'" in one  # macro tabs are real, shareable links
     assert "class='macrobar'" in two
-    assert "switchMacro('onboarding')" in two
+    assert "href='#onboarding'" in two
     # macro+org namespacing keeps the repeated org's section ids distinct per macro
     assert "id='governance-hiero-ledger-p'" in two and "id='onboarding-hiero-ledger-p'" in two
 

--- a/tests/pipelines/test_contributor_activity.py
+++ b/tests/pipelines/test_contributor_activity.py
@@ -103,6 +103,10 @@ def _patch_pipeline(
         "hiero_analytics.pipelines.contributor_activity.load_issue_label_events",
         lambda _client, _org: label_events,
     )
+    monkeypatch.setattr(
+        "hiero_analytics.pipelines.contributor_activity.fetch_org_merged_pr_difficulty_graphql",
+        lambda _client, _org, **_k: [],
+    )
 
     def _fake_repo_dirs(repo: str) -> tuple[Path, Path]:
         """Create and return per-repo output dirs under tmp_path."""

--- a/tests/pipelines/test_contributor_activity.py
+++ b/tests/pipelines/test_contributor_activity.py
@@ -13,6 +13,7 @@ import pytest
 matplotlib.use("Agg")
 
 import hiero_analytics.pipelines.contributor_activity as runner
+from hiero_analytics.data_sources.dataset_store import OfflineDatasetMissingError
 from hiero_analytics.data_sources.models import (
     ContributorActivityRecord,
     IssueTimelineEventRecord,
@@ -162,6 +163,31 @@ def test_main_creates_output_files(
     network_chart = tmp_path / "charts" / "all_network.png"
     assert network_chart.exists(), "Contributor network chart not created"
     assert os.path.getsize(network_chart) > 0, "Contributor network chart is empty"
+
+
+def test_main_skips_gfi_completers_when_offline_dataset_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    mock_github_client,
+    synthetic_activity,
+    synthetic_label_events,
+):
+    """An offline run without the merged-PR dataset skips the GFI tile, not the pipeline."""
+    _patch_pipeline(monkeypatch, tmp_path, mock_github_client, synthetic_activity, synthetic_label_events)
+
+    def _raise_offline_missing(_client, _org, **_k):
+        raise OfflineDatasetMissingError("Offline mode requires a valid cached dataset")
+
+    monkeypatch.setattr(
+        "hiero_analytics.pipelines.contributor_activity.fetch_org_merged_pr_difficulty_graphql",
+        _raise_offline_missing,
+    )
+
+    runner.main(ORG)
+
+    data_dir = tmp_path / "data"
+    assert not (data_dir / "gfi_completers.csv").exists()
+    assert (data_dir / "contributor_activity_profiles.csv").exists()
 
 
 def test_main_handles_empty_inputs(

--- a/tests/pipelines/test_dashboard.py
+++ b/tests/pipelines/test_dashboard.py
@@ -50,3 +50,30 @@ def test_generated_at_reads_sidecar_and_tolerates_absence(tmp_path):
 
     (tmp_path / "table.csv.meta.json").write_text("not json", encoding="utf-8")
     assert dashboard._generated_at(path) is None
+
+
+def test_contributor_metrics_tiles(tmp_path):
+    """The Contributors tiles: counts, shares over the full list, and the 30d active share."""
+    import pandas as pd
+
+    profiles = pd.DataFrame(
+        {
+            "contributor": ["a", "b", "c", "d"],
+            "repos_touched": [3, 1, 2, 1],
+            "issues_opened": [1, 0, 0, 2],
+            "prs_opened": [1, 1, 0, 0],
+            "reviews_given": [0, 4, 0, 0],
+        }
+    )
+    pd.DataFrame({"contributor": ["a"]}).to_csv(tmp_path / "contributor_activity_profiles_30d.csv", index=False)
+    pd.DataFrame({"login": ["a", "b"]}).to_csv(tmp_path / "gfi_completers.csv", index=False)
+
+    metrics = dict(dashboard._contributors_metrics({"profiles": profiles}, tmp_path))
+
+    assert metrics["contributors"] == 4
+    assert metrics["active last month %"] == "25%"
+    assert metrics["multi-repo %"] == "50%"
+    assert metrics["file issues %"] == "50%"
+    assert metrics["open PRs %"] == "50%"
+    assert metrics["give reviews %"] == "25%"
+    assert metrics["completed a GFI %"] == "50%"

--- a/tests/pipelines/test_dashboard.py
+++ b/tests/pipelines/test_dashboard.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from hiero_analytics.dashboard_spec import SECTION_SPECS
+from hiero_analytics.dashboard_spec import TABLE_FAMILIES
 from hiero_analytics.pipelines import dashboard
 
 
@@ -31,7 +31,8 @@ def test_load_period_variants_requires_the_flag(tmp_path):
 
 def test_activity_specs_use_the_shared_period_set():
     """The tabbed activity tables opt in via the flag; filenames derive centrally."""
-    tabbed = {spec["id"]: spec for spec in SECTION_SPECS if spec.get("periods")}
+    all_specs = [spec for family in TABLE_FAMILIES.values() for spec in family.SECTION_SPECS]
+    tabbed = {spec["id"]: spec for spec in all_specs if spec.get("periods")}
 
     assert set(tabbed) == {"profiles", "repoactivity", "understaffed", "loadshare", "repo", "teams"}
     assert all(spec["periods"] is True for spec in tabbed.values())


### PR DESCRIPTION
Fixes #257 

also ensures tabs are links, previously they just are front end buttons
also addds some more top level KPIs to the contributing tab, since the refactor left just 1 in this tab and it looked lonely