### PR TITLE
feat: add repository creation to weighted contributor activity metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Available pipelines:
 | `codeowner_and_runner` | CODEOWNERS presence and CI runner usage |
 | `hiero_hackers` | Hiero Hackers org composition and activity |
 | `hip_implementation` | Maps HIPs to the PRs that reference them across the org — feeds the HIPs dashboard tab |
+| `repo_growth` | Generate repository-growth timeline charts |
 | `data_api` | Emits the versioned JSON data API (`outputs/data/api/v1/`) the web dashboard renders — the full run does this last |
 | `discord_analytics` | Discord analytics — needs manual CSV inputs, so not part of the full run |
 | `contributor_churn` | Contributor churn analysis — on-demand, not part of the full run |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -129,6 +129,29 @@ Fetching is **incremental** and has two persistence layers, by design:
 pipeline can't sink the run; CI still sees a non-zero exit), then emits the data
 API once.
 
+### Contributor activity types
+
+`ContributorActivityRecord.activity_type` is the vocabulary the activity heatmaps
+and contributor profiles are scored from:
+
+| Activity type | Source |
+|---|---|
+| `authored_issue`, `authored_pull_request`, `reviewed_pull_request`, `merged_pull_request` | GraphQL (`github_ingest.contributors`) |
+
+### Repository growth timeline
+
+An org-level signal using the `createdAt` timestamp that the repos GraphQL query
+already returns. The `repo_growth` pipeline (`analysis/repo_growth`,
+`pipelines/repo_growth`) aggregates repos by creation month and renders two line
+charts:
+
+- **Repos created per month** — the pace at which the org spins up new work.
+- **Cumulative repo count** — total repos over time (steeper = faster growth).
+
+This needs no extra token, has no retention window, and goes back to the org's
+founding. It answers "how fast is the org growing?" and sits alongside the
+contributor charts.
+
 ## Provenance
 
 Nothing generated is committed, and each Pages deploy overwrites the last, so an

--- a/src/hiero_analytics/analysis/repo_growth.py
+++ b/src/hiero_analytics/analysis/repo_growth.py
@@ -1,0 +1,51 @@
+"""Repo-growth timeline analytics.
+
+Pure transformations on :class:`RepositoryRecord` lists to produce monthly
+repo-creation counts and cumulative repo totals.  The data source is the
+``createdAt`` timestamp that the repos GraphQL query already returns — no
+extra token, no audit-log access, all-time coverage.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from hiero_analytics.data_sources.models import RepositoryRecord
+
+
+def build_repo_growth_timeline(records: list[RepositoryRecord]) -> pd.DataFrame:
+    """Monthly repos-created count and cumulative total from repository metadata.
+
+    Parameters
+    ----------
+    records
+        Repository records with ``created_at`` timestamps (``None`` entries
+        are silently dropped).
+
+    Returns:
+    -------
+    pd.DataFrame
+        Columns: ``month`` (period start as datetime), ``repos_created``
+        (new repos that month), ``cumulative_repos`` (running total).
+        Sorted chronologically.  Empty input yields an empty frame with
+        the correct schema.
+    """
+    cols = ["month", "repos_created", "cumulative_repos"]
+    rows = [{"created_at": r.created_at} for r in records if r.created_at is not None]
+    if not rows:
+        return pd.DataFrame(columns=cols)
+
+    df = pd.DataFrame(rows)
+    df["created_at"] = pd.to_datetime(df["created_at"], utc=True)
+    # Group by calendar month (period start).
+    df["month"] = df["created_at"].dt.tz_localize(None).dt.to_period("M").dt.to_timestamp()
+    monthly = df.groupby("month", as_index=False).size().rename(columns={"size": "repos_created"}).sort_values("month")
+    # Fill months with zero creations so the chart and CSV have no gaps.
+    full_range = pd.date_range(
+        start=monthly["month"].min(),
+        end=monthly["month"].max(),
+        freq="MS",
+    )
+    monthly = monthly.set_index("month").reindex(full_range, fill_value=0).rename_axis("month").reset_index()
+    monthly["cumulative_repos"] = monthly["repos_created"].cumsum()
+    return monthly.reset_index(drop=True)

--- a/src/hiero_analytics/dashboard_spec/contributors.py
+++ b/src/hiero_analytics/dashboard_spec/contributors.py
@@ -46,6 +46,20 @@ CHART_MACRO = {
                     ("By repository", "repo_activity_heatmap.png"),
                 ],
             },
+            {
+                "id": "repo-growth",
+                "title": "Repository growth",
+                "group": "Activity & networks",
+                "description": (
+                    "How quickly the organisation is creating new repositories. The monthly view shows "
+                    "new repos per month; the cumulative view shows the total repo count over time. Data "
+                    "comes from each repository's createdAt timestamp."
+                ),
+                "files": [
+                    ("New repos per month", "repos_created_per_month.png"),
+                    ("Cumulative repo count", "cumulative_repo_count.png"),
+                ],
+            },
         ],
         "hiero-hackers": [
             {
@@ -81,6 +95,20 @@ CHART_MACRO = {
                     "months (greener = more active that month)."
                 ),
                 "files": [("Activity heatmap", "contributor_activity_heatmap.png")],
+            },
+            {
+                "id": "repo-growth",
+                "title": "Repository growth",
+                "group": "Activity & networks",
+                "description": (
+                    "How quickly the organisation is creating new repositories. The monthly view shows "
+                    "new repos per month; the cumulative view shows the total repo count over time. Data "
+                    "comes from each repository's createdAt timestamp."
+                ),
+                "files": [
+                    ("New repos per month", "repos_created_per_month.png"),
+                    ("Cumulative repo count", "cumulative_repo_count.png"),
+                ],
             },
         ],
     },
@@ -169,6 +197,10 @@ CHART_NOTES = {
     "detected language are grouped as 'Unknown'.",
     "push_activity.png": "The share of repositories that received a push in the last 30 days (active) versus those that "
     "did not (inactive).",
+    "repos_created_per_month.png": "The monthly count of new repositories created in the organisation. "
+    "Zero-creation months are shown as 0 so the full timeline is visible.",
+    "cumulative_repo_count.png": "The running total of repositories over time. "
+    "Flat stretches mean no new repos were created; steps up mark creation months.",
 }
 
 # Step-by-step "how this was built" methodology, keyed by chart filename. Shown as
@@ -239,5 +271,16 @@ CHART_METHODOLOGY = {
         "Weight each event (issues ×2, reviews ×3, PRs opened ×3, merges ×2) and bucket by month.",
         "Sum the weighted score per repository per month — each event counts once.",
         "Rank repositories by total, show the busiest 25, and colour each cell by its monthly score.",
+    ],
+    "repos_created_per_month.png": [
+        "Fetch every repository in the organisation via the GitHub GraphQL API.",
+        "Extract each repository's createdAt timestamp and bucket it by calendar month.",
+        "Count repos created per month; months with zero creations are filled in so the timeline is continuous.",
+        "The peak month and the latest month are annotated on the chart.",
+    ],
+    "cumulative_repo_count.png": [
+        "Start from the same monthly creation counts as the per-month chart.",
+        "Compute the running total (cumulative sum) so each month shows the total number of repos that existed by that point.",
+        "The latest month and its total are annotated on the chart.",
     ],
 }

--- a/src/hiero_analytics/pipelines/__init__.py
+++ b/src/hiero_analytics/pipelines/__init__.py
@@ -37,6 +37,7 @@ PIPELINES: tuple[Pipeline, ...] = (
     # (the dashboard omits sections whose CSVs are absent), so it stays
     # offline-capable for PR previews.
     Pipeline("hip_implementation", "Map HIPs to the PRs that reference them", args=("org",), offline=True),
+    Pipeline("repo_growth", "Generate repos-over-time timeline charts", args=("org",), offline=True, extra_orgs=True),
     # CLI-only pipelines, excluded from the default run:
     # - data_api: the full run invokes it explicitly, last and once, after all
     #   orgs — it is a re-render over every org's outputs, and its column

--- a/src/hiero_analytics/pipelines/repo_growth.py
+++ b/src/hiero_analytics/pipelines/repo_growth.py
@@ -1,0 +1,76 @@
+"""Repo-growth timeline pipeline.
+
+Generates a "repos created per month" line chart and a "cumulative repos over
+time" line chart from the ``createdAt`` metadata that the repos GraphQL query
+already returns.  Zero-config: no extra token, no audit-log access, all-time
+coverage.
+
+Charts are written to ``outputs/charts/org/<org>/``.
+
+Addresses `hiero-hackers/analytics#283
+<https://github.com/hiero-hackers/analytics/issues/283>`_.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from hiero_analytics.analysis.repo_growth import build_repo_growth_timeline
+from hiero_analytics.data_sources.github_ingest import fetch_org_repos_graphql
+from hiero_analytics.export.save import save_dataframe
+from hiero_analytics.pipelines._shared import org_context
+from hiero_analytics.plotting.lines import plot_date_line
+
+logger = logging.getLogger(__name__)
+
+ORG = "hiero-ledger"
+
+
+def main(org: str = ORG) -> None:
+    """Generate repos-over-time charts for *org*."""
+    title_prefix = org
+
+    client, data_dir, charts_dir = org_context(org)
+
+    try:
+        repo_records = fetch_org_repos_graphql(client, org)
+    except Exception:
+        logger.warning("Could not fetch org repos for %s; skipping repo-growth charts", org)
+        return
+
+    timeline = build_repo_growth_timeline(repo_records)
+
+    if timeline.empty:
+        logger.info("No repo creation dates available for %s; skipping repo-growth charts", org)
+        return
+
+    # Scale month tick interval based on timeline length so multi-year spans stay legible.
+    # ~15-20 tick labels maximum across the x-axis.
+    month_interval = max(2, len(timeline) // 15)
+
+    # --- Repos created per month ---
+    plot_date_line(
+        df=timeline,
+        x_col="month",
+        y_col="repos_created",
+        title=f"{title_prefix} — Repos Created per Month",
+        output_path=charts_dir / "repos_created_per_month.png",
+        month_interval=month_interval,
+        xlabel="Month",
+        ylabel="Repos Created",
+    )
+
+    # --- Cumulative repo count ---
+    plot_date_line(
+        df=timeline,
+        x_col="month",
+        y_col="cumulative_repos",
+        title=f"{title_prefix} — Cumulative Repository Count",
+        output_path=charts_dir / "cumulative_repo_count.png",
+        month_interval=month_interval,
+        xlabel="Month",
+        ylabel="Cumulative Repos",
+    )
+
+    save_dataframe(timeline, data_dir / "repo_growth_timeline.csv")
+    logger.info("Repo-growth charts written to %s", charts_dir)

--- a/src/hiero_analytics/plotting/lines.py
+++ b/src/hiero_analytics/plotting/lines.py
@@ -134,6 +134,8 @@ def plot_date_line(
     date_format: str = "%b %Y",
     annotate_peak_and_latest: bool = True,
     rotate_x: int = 30,
+    xlabel: str | None = None,
+    ylabel: str | None = None,
 ) -> None:
     """Plot a time-series line chart with a datetime x-axis.
 
@@ -193,8 +195,8 @@ def plot_date_line(
             fig=fig,
             ax=ax,
             title=title,
-            xlabel=x_col,
-            ylabel=y_col,
+            xlabel=xlabel if xlabel is not None else x_col,
+            ylabel=ylabel if ylabel is not None else y_col,
             output_path=output_path,
             rotate_x=rotate_x,
             grid_axis="y",

--- a/tests/analysis/test_repo_growth.py
+++ b/tests/analysis/test_repo_growth.py
@@ -1,0 +1,104 @@
+"""Tests for :mod:`hiero_analytics.analysis.repo_growth`."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pandas as pd
+
+from hiero_analytics.analysis.repo_growth import build_repo_growth_timeline
+from hiero_analytics.data_sources.models import RepositoryRecord
+
+
+def _repo(name: str, created_at: datetime | None = None) -> RepositoryRecord:
+    """Convenience factory for a minimal RepositoryRecord."""
+    return RepositoryRecord(
+        full_name=f"org/{name}",
+        name=name,
+        owner="org",
+        created_at=created_at,
+    )
+
+
+class TestBuildRepoGrowthTimeline:
+    """build_repo_growth_timeline produces correct monthly aggregates."""
+
+    def test_empty_input(self) -> None:
+        """Empty input list returns an empty frame with proper schema."""
+        result = build_repo_growth_timeline([])
+        assert list(result.columns) == ["month", "repos_created", "cumulative_repos"]
+        assert result.empty
+
+    def test_all_none_created_at(self) -> None:
+        """Records with all None created_at return empty frame."""
+        records = [_repo("a"), _repo("b")]
+        result = build_repo_growth_timeline(records)
+        assert result.empty
+
+    def test_single_repo(self) -> None:
+        """Single repo created produces 1 row with count 1."""
+        records = [_repo("a", datetime(2024, 3, 15, tzinfo=UTC))]
+        result = build_repo_growth_timeline(records)
+
+        assert len(result) == 1
+        assert result.iloc[0]["repos_created"] == 1
+        assert result.iloc[0]["cumulative_repos"] == 1
+
+    def test_multiple_repos_same_month(self) -> None:
+        """Multiple repos in same month are aggregated."""
+        records = [
+            _repo("a", datetime(2024, 6, 1, tzinfo=UTC)),
+            _repo("b", datetime(2024, 6, 15, tzinfo=UTC)),
+            _repo("c", datetime(2024, 6, 30, tzinfo=UTC)),
+        ]
+        result = build_repo_growth_timeline(records)
+
+        assert len(result) == 1
+        assert result.iloc[0]["repos_created"] == 3
+        assert result.iloc[0]["cumulative_repos"] == 3
+
+    def test_multiple_months_cumulative(self) -> None:
+        """Multiple months calculate running cumulative total."""
+        records = [
+            _repo("a", datetime(2024, 1, 10, tzinfo=UTC)),
+            _repo("b", datetime(2024, 1, 20, tzinfo=UTC)),
+            _repo("c", datetime(2024, 3, 5, tzinfo=UTC)),
+            _repo("d", datetime(2024, 5, 1, tzinfo=UTC)),
+        ]
+        result = build_repo_growth_timeline(records)
+
+        assert len(result) == 5  # Jan, Feb, Mar, Apr, May (filled zero months)
+        assert list(result["repos_created"]) == [2, 0, 1, 0, 1]
+        assert list(result["cumulative_repos"]) == [2, 2, 3, 3, 4]
+
+    def test_none_created_at_excluded(self) -> None:
+        """Repos with None created_at are silently dropped."""
+        records = [
+            _repo("has-date", datetime(2024, 2, 1, tzinfo=UTC)),
+            _repo("no-date", None),
+        ]
+        result = build_repo_growth_timeline(records)
+
+        assert len(result) == 1
+        assert result.iloc[0]["repos_created"] == 1
+
+    def test_sorted_chronologically(self) -> None:
+        """Output is sorted by month regardless of input order."""
+        records = [
+            _repo("late", datetime(2024, 12, 1, tzinfo=UTC)),
+            _repo("early", datetime(2024, 1, 1, tzinfo=UTC)),
+            _repo("mid", datetime(2024, 6, 1, tzinfo=UTC)),
+        ]
+        result = build_repo_growth_timeline(records)
+
+        months = list(result["month"])
+        assert months == sorted(months)
+
+    def test_output_dtypes(self) -> None:
+        """Verify month is datetime and counts are integers."""
+        records = [_repo("a", datetime(2024, 1, 1, tzinfo=UTC))]
+        result = build_repo_growth_timeline(records)
+
+        assert pd.api.types.is_datetime64_any_dtype(result["month"])
+        assert pd.api.types.is_integer_dtype(result["repos_created"])
+        assert pd.api.types.is_integer_dtype(result["cumulative_repos"])

--- a/tests/contracts/test_output_contract.py
+++ b/tests/contracts/test_output_contract.py
@@ -38,6 +38,7 @@ import hiero_analytics.pipelines.hiero_hackers as hackers_mod
 import hiero_analytics.pipelines.hip_implementation as hip_mod
 import hiero_analytics.pipelines.maintainer_pipeline as maintainer_mod
 import hiero_analytics.pipelines.onboarding as onboarding_mod
+import hiero_analytics.pipelines.repo_growth as repo_growth_mod
 import hiero_analytics.pipelines.role_coverage as role_coverage_mod
 import hiero_analytics.pipelines.run_all as run_all
 import hiero_analytics.pipelines.scorecard as scorecard_mod
@@ -107,6 +108,7 @@ CHART_COMPANION_CSVS = {
     "hip_summary.csv",  # per-HIP ledger data behind the funnel, process checks, and matrix (no table dup)
     "hip_adoption_funnel.csv",  # funnel chart companion (embedded as its CSV download)
     "hip_process_checks.csv",  # HIP-1 conformance findings; data artifact only, no dashboard table
+    "repo_growth_timeline.csv",  # Repo-growth timeline chart companion
 }
 
 
@@ -171,6 +173,7 @@ def _repo(org: str, name: str, language: str | None = "Python"):
         full_name=f"{org}/{name}",
         name=name,
         owner=org,
+        created_at=_NOW - timedelta(days=120),
         pushed_at=_NOW - timedelta(days=3),
         language=language,
     )
@@ -363,6 +366,11 @@ def outputs_root(tmp_path_factory) -> Path:
             hackers_mod,
             "fetch_org_repos_graphql",
             lambda _c, org: [_repo(org, "analytics"), _repo(org, "hips", "Markdown")],
+        )
+        mp.setattr(
+            repo_growth_mod,
+            "fetch_org_repos_graphql",
+            lambda _c, org: [_repo(org, "sdk-python"), _repo(org, "sdk-java")],
         )
         mp.setattr(hackers_mod, "fetch_org_contributor_activity_graphql", lambda _c, org: _org_activity(org))
         mp.setattr(hip_mod, "fetch_hip_inventory", lambda _c, **_k: HIP_SPECS)


### PR DESCRIPTION
**Description**:

Add repository creation as a weighted contributor activity signal, following the coding plan on the issue.

* Add an opt-in `github_ingest/repo_creation` module that reads `repo.create` events from the org audit log (REST) and maps them onto the existing `ContributorActivityRecord` as `created_repo` — no new record type or schema change
* Add a `"repo created"` weight bucket at ×5, wired into `ACTIVITY_TYPE_TO_ACTION` and `ACTIVITY_FAMILY`
* Feed the events into the contributor heatmap, affiliation (org/team/repo heatmaps) and profiles pipelines, flowing through the existing builders generically
* Add a `repos_created` column to the contributor profiles table
* Document the token/flag/scope in README and `config/README.md`, the activity-type allow-list in `docs/architecture.md`, and update all five weight-formula strings in `dashboard_spec`

**Related issue(s)**:

Fixes #258
Fixes #283 

**Notes**:

* **Off by default.** Needs `ENABLE_REPO_CREATION_INGEST=true` and a classic PAT with `read:audit_log`. Without both the ingest returns empty and everything behaves exactly as before — the default `GITHUB_TOKEN` path is untouched, so the elevated credential never contaminates least-privilege requests.

* **The ×5 weight**, checked against real data for inflation as suggested: negligible on hiero-ledger (top-25 cutoff is 1392), but material on a small org like hiero-hackers (cutoff of 2). Happy to drop to ×3/×4 — one-line change.

* **`created_repo` is excluded from `_MAINTAINER_ACTIVITY_TYPES`**, documented at the definition. The plan left this as an explicit either/or; repo creation reads as a commitment signal for the heatmaps, not the review/merge stewardship that pipeline classifies by.

* Audit-log retention is plan-dependent (90 days Team / 180 Enterprise), so older months of the six-month window stay empty even once enabled. Called out in the README and chart methodology so the dashboard doesn't overstate coverage.