### PR TITLE
Update heatmaps colour

### DIFF
--- a/src/hiero_analytics/config/charts.py
+++ b/src/hiero_analytics/config/charts.py
@@ -176,12 +176,12 @@ SCORECARD_CHECK_COLORS = {
 
 # Contributor activity heatmap: the intensity colour scale plus the surrounding
 # chrome colours (figure/axes background, cell text, ticks).
-ACTIVITY_HEATMAP_CMAP = "RdYlGn"
+ACTIVITY_HEATMAP_CMAP = "YlGnBu"
 ACTIVITY_HEATMAP_PALETTE = {
     "figure_bg": "#F6F8FB",
     "axes_bg": "#FFFFFF",
-    "text_dark": "#0F172A",
-    "text_light": "#FFFFFF",
+    "text_dark": "#272829",
+    "text_light": "#EBE5E5",
     "tick": "#64748B",
 }
 


### PR DESCRIPTION
**Description**:
This PR 
This pull request updates the color scheme for the contributor activity heatmap in the `src/hiero_analytics/config/charts.py` configuration file. The main changes involve switching to a new colormap and adjusting the associated palette colors for improved visual clarity.

* Changed the heatmap colormap from `"RdYlGn"` to `"YlGnBu"` for a cooler color gradient.

**Related issue(s)**:
Fixes #281 

**Notes for reviewer**:
<img width="3600" height="3712" alt="image" src="https://github.com/user-attachments/assets/376360f4-57ef-45b1-b1cf-3447b4024721" />


**Checklist**

- [ ] Tests added/updated for the change (mirroring the `src/` layout)
- [ ] Commits are signed and signed-off: `git commit -S -s`
- [ ] Docs updated if relevant
