### PR TITLE
Add a top-level permissions block

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: "CodeQL Advanced"
 
+permissions:
+  contents: read
+
 on:
     push:
         branches: ["main"]


### PR DESCRIPTION
**Description**:
- The workflow now enforces least privilege at the top level.
- Each job can still request additional permissions (security-events: write, packages: read) as needed.


**Related issue(s)**:

Fixes #313 

**Notes for reviewer**:
<!-- Screenshots of new/changed charts, sample output, or anything that helps review. -->

**Checklist**

- [ ] Commits are signed and signed-off: `git commit -S -s`
- [ ] Docs updated if relevant
