### PR TITLE
fix: align STALE_AFTER with the 5-day refresh cadence

### DIFF
--- a/src/hiero_analytics/export/data_api.py
+++ b/src/hiero_analytics/export/data_api.py
@@ -61,10 +61,7 @@ API_VERSION = "v1"
 
 # A section counts as stale when its data is older than the scheduled refresh
 # cadence plus slack for a slow run — the same policy the legacy dashboard
-# applies, imported from here so the two cannot drift. The workflow runs every
-# 5 days (120h, .github/workflows/update-analytics.yml); 12h slack covers its
-# ~6h job timeout plus room for a delayed run start, while staying well short
-# of a second missed cycle.
+# applies, imported from here so the two cannot drift.
 STALE_AFTER = timedelta(hours=132)
 
 

--- a/src/hiero_analytics/export/data_api.py
+++ b/src/hiero_analytics/export/data_api.py
@@ -60,8 +60,9 @@ logger = logging.getLogger(__name__)
 API_VERSION = "v1"
 
 # A section counts as stale when its data is older than the scheduled refresh
-# cadence plus slack for a slow run — the same policy the legacy dashboard
-# applies, imported from here so the two cannot drift.
+# cadence plus slack for a slow run. The analytics refresh runs every 5 days,
+# and we add 12 hours of slack for slow or delayed runs. The legacy dashboard
+# imports this value so the two cannot drift.
 STALE_AFTER = timedelta(hours=132)
 
 

--- a/src/hiero_analytics/export/data_api.py
+++ b/src/hiero_analytics/export/data_api.py
@@ -61,8 +61,11 @@ API_VERSION = "v1"
 
 # A section counts as stale when its data is older than the scheduled refresh
 # cadence plus slack for a slow run — the same policy the legacy dashboard
-# applies, imported from here so the two cannot drift.
-STALE_AFTER = timedelta(hours=36)
+# applies, imported from here so the two cannot drift. The workflow runs every
+# 5 days (120h, .github/workflows/update-analytics.yml); 12h slack covers its
+# ~6h job timeout plus room for a delayed run start, while staying well short
+# of a second missed cycle.
+STALE_AFTER = timedelta(hours=132)
 
 
 class DataApiContractError(RuntimeError):

--- a/tests/export/test_data_api.py
+++ b/tests/export/test_data_api.py
@@ -97,7 +97,7 @@ def test_section_action_link_is_shipped(api_env: Path, tmp_path: Path, monkeypat
 
 
 def test_data_within_stale_after_is_not_stale(api_env: Path, tmp_path: Path):
-    """A section stamped just inside STALE_AFTER is not flagged stale."""
+    """Boundary check: STALE_AFTER minus a few minutes stays fresh."""
     generated_at = datetime.now(UTC) - data_api.STALE_AFTER + timedelta(minutes=5)
     frame = pd.DataFrame({"name": ["a"], "count": [3], "last_seen": ["2026-07-01"]})
     frame.to_csv(api_env / "widgets.csv", index=False)
@@ -112,7 +112,7 @@ def test_data_within_stale_after_is_not_stale(api_env: Path, tmp_path: Path):
 
 
 def test_data_past_stale_after_is_stale(api_env: Path, tmp_path: Path):
-    """A section stamped past STALE_AFTER is flagged stale for the dashboard badge."""
+    """Boundary check: the other side of the same line trips the badge."""
     generated_at = datetime.now(UTC) - data_api.STALE_AFTER - timedelta(minutes=5)
     frame = pd.DataFrame({"name": ["a"], "count": [3], "last_seen": ["2026-07-01"]})
     frame.to_csv(api_env / "widgets.csv", index=False)

--- a/tests/export/test_data_api.py
+++ b/tests/export/test_data_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -93,6 +94,36 @@ def test_section_action_link_is_shipped(api_env: Path, tmp_path: Path, monkeypat
 
     document = json.loads((tmp_path / "data" / "api" / API_VERSION / ORG / "widgets.json").read_text())
     assert document["action"] == {"url": "https://example.test/issues/new", "label": "Suggest a correction"}
+
+
+def test_data_within_stale_after_is_not_stale(api_env: Path, tmp_path: Path):
+    """A section stamped just inside STALE_AFTER is not flagged stale."""
+    generated_at = datetime.now(UTC) - data_api.STALE_AFTER + timedelta(minutes=5)
+    frame = pd.DataFrame({"name": ["a"], "count": [3], "last_seen": ["2026-07-01"]})
+    frame.to_csv(api_env / "widgets.csv", index=False)
+    Path(f"{api_env / 'widgets.csv'}.meta.json").write_text(
+        json.dumps({"generated_at": generated_at.isoformat(), "record_count": len(frame)})
+    )
+
+    emit_data_api()
+
+    document = json.loads((tmp_path / "data" / "api" / API_VERSION / ORG / "widgets.json").read_text())
+    assert document["stale"] is False
+
+
+def test_data_past_stale_after_is_stale(api_env: Path, tmp_path: Path):
+    """A section stamped past STALE_AFTER is flagged stale for the dashboard badge."""
+    generated_at = datetime.now(UTC) - data_api.STALE_AFTER - timedelta(minutes=5)
+    frame = pd.DataFrame({"name": ["a"], "count": [3], "last_seen": ["2026-07-01"]})
+    frame.to_csv(api_env / "widgets.csv", index=False)
+    Path(f"{api_env / 'widgets.csv'}.meta.json").write_text(
+        json.dumps({"generated_at": generated_at.isoformat(), "record_count": len(frame)})
+    )
+
+    emit_data_api()
+
+    document = json.loads((tmp_path / "data" / "api" / API_VERSION / ORG / "widgets.json").read_text())
+    assert document["stale"] is True
 
 
 def test_missing_declared_column_fails_loudly(api_env: Path):

--- a/tests/export/test_data_api.py
+++ b/tests/export/test_data_api.py
@@ -98,6 +98,7 @@ def test_section_action_link_is_shipped(api_env: Path, tmp_path: Path, monkeypat
 
 def test_data_within_stale_after_is_not_stale(api_env: Path, tmp_path: Path):
     """Boundary check: STALE_AFTER minus a few minutes stays fresh."""
+    assert timedelta(hours=132) == data_api.STALE_AFTER
     generated_at = datetime.now(UTC) - data_api.STALE_AFTER + timedelta(minutes=5)
     frame = pd.DataFrame({"name": ["a"], "count": [3], "last_seen": ["2026-07-01"]})
     frame.to_csv(api_env / "widgets.csv", index=False)


### PR DESCRIPTION
**Description**:

Align the `STALE_AFTER` threshold with the actual 5-day analytics refresh schedule to prevent incorrect stale status in exported data and the dashboard.

* Update `STALE_AFTER` from 36 hours to 132 hours (5 days + 12-hour buffer)
* Document the actual refresh cadence and rationale in the code
* Add tests covering stale/non-stale boundary behavior using `STALE_AFTER`
* Keep the change scoped to the stale threshold without modifying the overall stale computation design

**Related issue(s)**:

Fixes #341 

**Notes for reviewer**:

* Added boundary tests for the `stale` flag to prevent future drift between the constant and its expected behavior.
* Verified locally:

  * `uv run pytest`  

**Checklist**

* [x] I claimed the linked issue with `/assign` before starting (see [[contributing guide](https://github.com/hiero-hackers/analytics/blob/main/CONTRIBUTING.md#workflow)](https://github.com/hiero-hackers/analytics/blob/main/CONTRIBUTING.md#workflow))
* [x] `uv run pytest` and `uv run ruff check src tests` pass locally
* [x] Tests added/updated for the change (mirroring the `src/` layout)
* [x] Commits are signed and signed-off: `git commit -S -s`
* [ ] Docs updated if relevant