### PR TITLE
feat: add fail-fast option to full pipeline run

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ uv run hiero-analytics
 - Writes charts to `outputs/charts/` and data tables to `outputs/data/`
 - Isolates failures — if one pipeline errors it is logged and the rest still run; the command exits non-zero if any failed
 
+For faster local debugging, run the explicit `all` command with `--fail-fast`:
+
+```bash
+uv run hiero-analytics all --fail-fast
+```
+
+This stops after the first pipeline failure and exits non-zero immediately, so
+the original traceback is not buried beneath output from later pipelines.
+Without `--fail-fast`, the default behaviour is unchanged: failures are logged,
+the remaining pipelines continue, and all failures are reported at the end.
+
 Everything under `outputs/` is generated and gitignored. The scheduled workflow publishes the dashboard to GitHub Pages instead of committing generated charts and reports.
 
 This is the same command the scheduled **Refresh Analytics Data** workflow runs.

--- a/src/hiero_analytics/cli.py
+++ b/src/hiero_analytics/cli.py
@@ -40,7 +40,12 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="<command>",
     )
 
-    subparsers.add_parser("all", help="Run the full suite of analytics pipelines (the default)")
+    all_parser = subparsers.add_parser("all", help="Run the full suite of analytics pipelines (the default)")
+    all_parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop after the first pipeline failure instead of continuing",
+    )
     for pipeline in PIPELINES:
         subparser = subparsers.add_parser(pipeline.name, help=pipeline.description)
         for option in pipeline.args:
@@ -55,7 +60,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     command = args.command or "all"
 
     if command == "all":
-        run_all.main()  # does its own logging setup; exits non-zero on any failure
+        # Bare `hiero-analytics` has no --fail-fast; only the explicit `all` subcommand does.
+        fail_fast = getattr(args, "fail_fast", False)
+        run_all.main(fail_fast=fail_fast)  # does its own logging setup; exits non-zero on any failure
         return 0
 
     pipeline = PIPELINES_BY_NAME[command]

--- a/src/hiero_analytics/pipelines/run_all.py
+++ b/src/hiero_analytics/pipelines/run_all.py
@@ -50,14 +50,25 @@ def default_pipelines() -> list[tuple[str, Callable[[], None]]]:
     return [(pipeline.name, pipeline.resolve()) for pipeline in default_run_pipelines()]
 
 
-def run_pipelines(pipelines: list[tuple[str, Callable[[], None]]]) -> list[str]:
-    """Run each pipeline, isolating failures. Returns the names that failed."""
+def run_pipelines(
+    pipelines: list[tuple[str, Callable[[], None]]],
+    *,
+    fail_fast: bool = False,
+) -> list[str]:
+    """Run each pipeline, isolating failures. Returns the names that failed.
+
+    With ``fail_fast=True``, stop after the first failure instead of continuing.
+    """
     failures: list[str] = []
     for name, pipeline in pipelines:
         logger.info("=== Running pipeline: %s ===", name)
         try:
             pipeline()
         except Exception:
+            if fail_fast:
+                logger.exception("Pipeline %s failed; stopping due to --fail-fast", name)
+                failures.append(name)
+                return failures
             logger.exception("Pipeline %s failed; continuing with the rest", name)
             failures.append(name)
     return failures
@@ -100,14 +111,20 @@ def _run_extra_org(org: str) -> bool:
     return True
 
 
-def main() -> None:
+def main(*, fail_fast: bool = False) -> None:
     """Run the primary-org pipelines, extra-org activity, then the data API once.
 
-    Exits non-zero if any pipeline (or the API emit) failed.
+    Exits non-zero if any pipeline (or the API emit) failed. With
+    ``fail_fast=True``, stop after the first primary-org pipeline failure and
+    skip the remaining work (extra orgs, snapshot manifest, data API).
     """
     setup_logging()
 
-    failures = run_pipelines(pipelines_for_current_mode())
+    failures = run_pipelines(pipelines_for_current_mode(), fail_fast=fail_fast)
+    if fail_fast and failures:
+        logger.error("%d pipeline(s) failed: %s", len(failures), ", ".join(failures))
+        raise SystemExit(1)
+
     failures += [f"contributor_activity[{org}]" for org in EXTRA_ORGS if not _run_extra_org(org)]
 
     # Describe the snapshot before the data API emits against it. Written

--- a/tests/pipelines/test_run_all.py
+++ b/tests/pipelines/test_run_all.py
@@ -25,6 +25,23 @@ def test_run_pipelines_runs_all_and_isolates_failures():
     assert failures == ["b"]
 
 
+def test_run_pipelines_fail_fast_stops_after_first_failure():
+    """With fail_fast, the first failure aborts the remaining pipelines."""
+    calls = []
+
+    def boom():
+        calls.append("a")
+        raise RuntimeError("kaboom")
+
+    def ok_b():
+        calls.append("b")
+
+    failures = run_all.run_pipelines([("a", boom), ("b", ok_b)], fail_fast=True)
+
+    assert calls == ["a"]
+    assert failures == ["a"]
+
+
 def test_run_extra_org_calls_runner_in_process_with_org(monkeypatch):
     """Extra orgs run the contributor-activity runner in-process, passing the org explicitly."""
     seen = []
@@ -104,6 +121,29 @@ def test_main_exits_nonzero_when_a_pipeline_fails(monkeypatch):
         run_all.main()
 
     assert exc_info.value.code == 1
+
+
+def test_main_fail_fast_skips_remaining_work_after_pipeline_failure(monkeypatch):
+    """With fail_fast, main() exits after the first failure and skips later stages."""
+
+    def boom():
+        raise RuntimeError("fail")
+
+    monkeypatch.setattr(run_all, "setup_logging", lambda: None)
+    monkeypatch.setattr(run_all, "default_pipelines", lambda: [("boom", boom), ("later", lambda: None)])
+    monkeypatch.setattr(run_all, "EXTRA_ORGS", ["extra-org"])
+
+    extra_org_calls = []
+    resolve_calls = []
+    monkeypatch.setattr(run_all, "_run_extra_org", lambda org: extra_org_calls.append(org) or True)
+    monkeypatch.setattr(run_all, "_resolve", lambda name: resolve_calls.append(name) or (lambda: None))
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_all.main(fail_fast=True)
+
+    assert exc_info.value.code == 1
+    assert extra_org_calls == []
+    assert resolve_calls == []
 
 
 def test_main_succeeds_when_all_pipelines_pass(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -63,8 +63,17 @@ def test_cli_reports_pipeline_failure_with_exit_code(monkeypatch):
 def test_cli_defaults_to_full_run(monkeypatch):
     """No arguments (and the `all` command) run the full suite."""
     ran = []
-    monkeypatch.setattr(cli.run_all, "main", lambda: ran.append(True))
+    monkeypatch.setattr(cli.run_all, "main", lambda fail_fast=False: ran.append(fail_fast))
 
     assert cli.main([]) == 0
     assert cli.main(["all"]) == 0
-    assert ran == [True, True]
+    assert ran == [False, False]
+
+
+def test_cli_all_forwards_fail_fast(monkeypatch):
+    """The explicit `all --fail-fast` flag is forwarded to run_all.main()."""
+    seen = []
+    monkeypatch.setattr(cli.run_all, "main", lambda fail_fast=False: seen.append(fail_fast))
+
+    assert cli.main(["all", "--fail-fast"]) == 0
+    assert seen == [True]


### PR DESCRIPTION
**Description**:

Add `--fail-fast` to the full pipeline run so local debugging stops at the first primary pipeline failure instead of continuing through the rest of the suite.

* Add keyword-only `fail_fast` to `run_pipelines()` and `run_all.main()`
* Stop after the first primary pipeline failure and exit with status `1`
* Skip extra-org work, snapshot manifest, and data API when fail-fast triggers
* Expose `--fail-fast` on the explicit `all` CLI subcommand only
* Cover both default and fail-fast behaviour in tests

**Related issue(s)**:

Fixes #324

**Notes for reviewer**:

Default behaviour (`hiero-analytics` / `hiero-analytics all`) is unchanged: failures remain isolated and the run continues. Only `hiero-analytics all --fail-fast` opts into early exit.

**Checklist**

- [x] I claimed the linked issue with `/assign` before starting (see [contributing guide](https://github.com/hiero-hackers/analytics/blob/main/CONTRIBUTING.md#workflow))
- [x] `uv run pytest` and `uv run ruff check src tests` pass locally
- [x] Tests added/updated for the change (mirroring the `src/` layout)
- [x] Commits are signed and signed-off: `git commit -S -s`
- [ ] Docs updated if relevant