### PR TITLE
fix: warn and document when cache TTL <= 0 disables expiry

### DIFF
--- a/src/hiero_analytics/data_sources/README.md
+++ b/src/hiero_analytics/data_sources/README.md
@@ -228,6 +228,11 @@ Environment variables:
 GITHUB_CACHE_ENABLED=true
 GITHUB_CACHE_TTL_SECONDS=900
 ```
+Setting `GITHUB_CACHE_TTL_SECONDS` to `0` or a negative number disables
+expiry entirely — entries are treated as fresh forever and only go away if
+you clear `outputs/cache/github/` by hand. This is intentional (handy for
+offline debugging), but easy to trigger by accident with an empty or
+malformed value, so using it logs a warning rather than failing silently.
 
 You can also override caching per call:
 

--- a/src/hiero_analytics/data_sources/cache.py
+++ b/src/hiero_analytics/data_sources/cache.py
@@ -1,4 +1,16 @@
-"""File-backed cache helpers for normalized GitHub data records."""
+"""File-backed cache helpers for normalized GitHub data records.
+
+Freshness is governed by ``GITHUB_CACHE_TTL_SECONDS`` or the
+``ttl_seconds`` override. A positive value expires cache entries older
+than the configured number of seconds. A value of ``0`` or less
+disables expiry and keeps cache entries indefinitely until the cache
+directory is cleared manually. This behavior is intended as an explicit
+"cache forever" mode (for example, during offline debugging).
+
+Because an empty or invalid environment variable also resolves to
+``0``, the cache logs a warning when non-positive TTL mode is active so
+the configuration is explicit and visible.
+"""
 
 from __future__ import annotations
 
@@ -35,13 +47,29 @@ def _cache_enabled(use_cache: bool | None) -> bool:
 
 
 def _cache_ttl_seconds(ttl_seconds: int | None) -> int:
-    """Resolve the effective cache TTL in seconds."""
+    """Resolve the effective cache TTL in seconds.
+
+    A resolved value of ``0`` or less disables cache expiry (see the module
+    docstring). Because an empty or invalid ``GITHUB_CACHE_TTL_SECONDS`` value
+    can also resolve to ``0``, a warning is logged whenever non-positive TTL
+    mode is active.
+    """
     if ttl_seconds is not None:
-        return ttl_seconds
-    return env_int(
-        "GITHUB_CACHE_TTL_SECONDS",
-        DEFAULT_GITHUB_CACHE_TTL_SECONDS,
-    )
+        resolved = ttl_seconds
+    else:
+        resolved = env_int(
+            "GITHUB_CACHE_TTL_SECONDS",
+            DEFAULT_GITHUB_CACHE_TTL_SECONDS,
+        )
+
+    if resolved <= 0:
+        logger.warning(
+            "Cache TTL resolved to %d (<=0); cache expiry is disabled. "
+            "Entries will remain until the cache directory is cleared manually.",
+            resolved,
+        )
+
+    return resolved
 
 
 def _slugify(value: str) -> str:

--- a/src/hiero_analytics/data_sources/cache.py
+++ b/src/hiero_analytics/data_sources/cache.py
@@ -112,6 +112,7 @@ def load_records_cache(  # noqa: UP047
     if not _cache_enabled(use_cache):
         return None
 
+    effective_ttl_seconds = _cache_ttl_seconds(ttl_seconds)
     cache_path = _cache_path(kind, scope, parameters)
     if refresh or not cache_path.exists():
         return None
@@ -148,7 +149,6 @@ def load_records_cache(  # noqa: UP047
         logger.info("Ignoring cache file with invalid timestamp: %s", cache_path)
         return None
 
-    effective_ttl_seconds = _cache_ttl_seconds(ttl_seconds)
     if effective_ttl_seconds > 0:
         age_seconds = (datetime.now(UTC) - cached_at).total_seconds()
         if age_seconds > effective_ttl_seconds:

--- a/tests/data_sources/test_cache.py
+++ b/tests/data_sources/test_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock
 
@@ -221,6 +222,52 @@ def test_stale_cache_entry_is_ignored(_temp_cache_dir):
     )
 
     assert loaded is None
+
+
+@pytest.mark.parametrize("ttl_seconds", [0, -1, -3600])
+def test_non_positive_ttl_never_expires_and_warns(_temp_cache_dir, caplog, ttl_seconds):
+    """TTL <= 0 is a deliberate 'cache forever' escape hatch, but a loud one."""
+    records = [
+        IssueRecord(
+            repo="org/repo",
+            number=1,
+            title="Issue A",
+            state="OPEN",
+            created_at=datetime(2024, 1, 1, tzinfo=UTC),
+            closed_at=None,
+            labels=["bug"],
+        )
+    ]
+    parameters = {"owner": "org", "repo": "repo", "states": []}
+
+    cache.save_records_cache(
+        "repo_issues",
+        "org_repo",
+        parameters,
+        IssueRecord,
+        records,
+        use_cache=True,
+    )
+
+    # Backdate the entry well past any TTL a positive value could plausibly
+    # allow, so this only passes if expiry was genuinely skipped.
+    cache_path = cache._cache_path("repo_issues", "org_repo", parameters)
+    payload = json.loads(cache_path.read_text(encoding="utf-8"))
+    payload["cached_at"] = (datetime.now(UTC) - timedelta(days=365)).isoformat()
+    cache_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger="hiero_analytics.data_sources.cache"):
+        loaded = cache.load_records_cache(
+            "repo_issues",
+            "org_repo",
+            parameters,
+            IssueRecord,
+            use_cache=True,
+            ttl_seconds=ttl_seconds,
+        )
+
+    assert loaded == records
+    assert any("never expire" in record.message for record in caplog.records)
 
 
 def test_mismatched_parameters_is_a_cache_miss(_temp_cache_dir):

--- a/tests/data_sources/test_cache.py
+++ b/tests/data_sources/test_cache.py
@@ -267,7 +267,30 @@ def test_non_positive_ttl_never_expires_and_warns(_temp_cache_dir, caplog, ttl_s
         )
 
     assert loaded == records
-    assert any("never expire" in record.message for record in caplog.records)
+    assert any(
+        record.levelno == logging.WARNING and "Cache TTL resolved to" in record.message for record in caplog.records
+    )
+
+
+def test_non_positive_ttl_warns_with_missing_cache(caplog):
+    """Non-positive TTL emits a warning before any cache-read early return."""
+    parameters = {"owner": "org", "repo": "repo", "states": []}
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="hiero_analytics.data_sources.cache",
+    ):
+        loaded = cache.load_records_cache(
+            "repo_issues",
+            "org_repo",
+            parameters,
+            IssueRecord,
+            use_cache=True,
+            ttl_seconds=0,
+        )
+
+    assert loaded is None
+    assert any("Cache TTL resolved to" in record.message for record in caplog.records)
 
 
 def test_mismatched_parameters_is_a_cache_miss(_temp_cache_dir):


### PR DESCRIPTION
**Description**:

Document and make non-positive cache TTL behavior explicit.

* Document the semantics of `GITHUB_CACHE_TTL_SECONDS <= 0` in the cache module and README
* Log a warning when cache expiry is disabled by a non-positive TTL
* Add tests covering both expiring and non-expiring cache behavior

**Related issue(s)**:

Fixes #345

**Notes for reviewer**:

A non-positive cache TTL is retained as an explicit "cache forever" mode rather than treated as an error. This PR makes that behavior visible by documenting it and emitting a warning when it is active, while preserving the existing cache semantics.

**Checklist**

* [x] I claimed the linked issue with `/assign` before starting (see [[contributing guide](https://github.com/hiero-hackers/analytics/blob/main/CONTRIBUTING.md#workflow)](https://github.com/hiero-hackers/analytics/blob/main/CONTRIBUTING.md#workflow))
* [x] `uv run pytest` and `uv run ruff check src tests` pass locally
* [x] Tests added/updated for the change (mirroring the `src/` layout)
* [x] Commits are signed and signed-off: `git commit -S -s`
* [x] Docs updated if relevant