### PR TITLE
Fix default org in repo-growth pipeline from shared config

### DIFF
--- a/src/hiero_analytics/pipelines/repo_growth.py
+++ b/src/hiero_analytics/pipelines/repo_growth.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 
 from hiero_analytics.analysis.repo_growth import build_repo_growth_timeline
+from hiero_analytics.config.paths import ORG
 from hiero_analytics.data_sources.github_ingest import fetch_org_repos_graphql
 from hiero_analytics.export.save import save_dataframe
 from hiero_analytics.pipelines._shared import org_context
@@ -23,13 +24,9 @@ from hiero_analytics.plotting.lines import plot_date_line
 
 logger = logging.getLogger(__name__)
 
-ORG = "hiero-ledger"
-
 
 def main(org: str = ORG) -> None:
     """Generate repos-over-time charts for *org*."""
-    title_prefix = org
-
     client, data_dir, charts_dir = org_context(org)
 
     try:
@@ -53,7 +50,7 @@ def main(org: str = ORG) -> None:
         df=timeline,
         x_col="month",
         y_col="repos_created",
-        title=f"{title_prefix} — Repos Created per Month",
+        title=f"{org} — Repos Created per Month",
         output_path=charts_dir / "repos_created_per_month.png",
         month_interval=month_interval,
         xlabel="Month",
@@ -65,7 +62,7 @@ def main(org: str = ORG) -> None:
         df=timeline,
         x_col="month",
         y_col="cumulative_repos",
-        title=f"{title_prefix} — Cumulative Repository Count",
+        title=f"{org} — Cumulative Repository Count",
         output_path=charts_dir / "cumulative_repo_count.png",
         month_interval=month_interval,
         xlabel="Month",


### PR DESCRIPTION
Fixes #355

Summary:

repo_growth.py hardcoded ORG = "hiero-ledger" instead of importing the shared ORG from hiero_analytics.config.paths, so it silently ignored the GITHUB_ORG env var that every other pipeline respects. Also removed the redundant title_prefix alias — the two chart titles just use org directly now.

Changes
src/hiero_analytics/pipelines/repo_growth.py: import ORG from hiero_analytics.config.paths instead of a local hardcoded constant; removed title_prefix, using org directly in both chart titles

Testing
uv run pytest ✅ (721 passed, 95% coverage)
uv run ruff check src tests ✅