### PR TITLE
fix: offset group jump targets

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -48,6 +48,7 @@
   --r-frame: 8px; /* inputs, scroll boxes, and framed chart media */
   --r-pill: 999px;
   --dur: 120ms;
+  --jump-h: 58px; /* sticky jump bar height + small scroll buffer */
 
   /* Deliberately outside the light/dark flip below.
      --chart-ground: chart PNGs carry a baked-in light background, so their
@@ -708,6 +709,10 @@
   .lbmethod li {
     margin: 5px 0;
   }
+  :root {
+    /* existing variables... */
+    --jump-h: 58px;
+  }
 
   /* Jump bar & groups */
   .jump {
@@ -722,6 +727,9 @@
     padding: 10px 0;
     margin: 0 0 6px;
     border-bottom: 1px solid var(--edge);
+  }
+  .group {
+  scroll-margin-top: var(--jump-h);
   }
   .jlabel {
     font-size: 12px;

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -709,10 +709,6 @@
   .lbmethod li {
     margin: 5px 0;
   }
-  :root {
-    /* existing variables... */
-    --jump-h: 58px;
-  }
 
   /* Jump bar & groups */
   .jump {
@@ -721,7 +717,9 @@
     z-index: 50;
     display: flex;
     gap: 8px;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
     align-items: center;
     background: var(--page);
     padding: 10px 0;


### PR DESCRIPTION
**Description**:

Fix group jump navigation so that target headings are not hidden behind the sticky jump bar.

* Add `scroll-margin-top` to `.group` elements
* Account for the sticky jump bar when navigating to groups

**Related issue(s)**:

Fixes #340

**Notes for reviewer**:

The jump targets now reserve space for the sticky jump bar, keeping group headings visible after navigation.

**Checklist**

* [x] I claimed the linked issue with `/assign` before starting (see [[contributing guide](https://github.com/hiero-hackers/analytics/blob/main/CONTRIBUTING.md#workflow)](https://github.com/hiero-hackers/analytics/blob/main/CONTRIBUTING.md#workflow))
* [ ] `uv run pytest` and `uv run ruff check src tests` pass locally
* [ ] Tests added/updated for the change (mirroring the `src/` layout)
* [x] Commits are signed and signed-off: `git commit -S -s`
* [ ] Docs updated if relevant