### PR TITLE
fix: design the loading, empty-filter, and error states

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { MetricTiles } from "./components/MetricTiles";
 import { ProvenanceFooter } from "./components/ProvenanceFooter";
 import { SectionGroups, type Group } from "./components/SectionGroups";
 import { SectionTable } from "./components/SectionTable";
+import { Skeleton } from "./components/Skeleton";
 import { TabBar } from "./components/TabBar";
 import { WipFooter } from "./components/WipFooter";
 import { stamp } from "./format";
@@ -93,28 +94,43 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
           {unavailable.join(", ")}. Everything else on this tab is unaffected — reload to try again.
         </p>
       )}
-      <SectionGroups groups={groups} />
+      {settled ? <SectionGroups groups={groups} /> : <Skeleton label="Loading tab" rows={6} />}
     </>
   );
 }
 
-export default function App() {
-  const [manifest, setManifest] = useState<Manifest | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [macro, setMacro] = useHashState("tab", "");
-  const [org, setOrg] = useHashState("org", "");
+/** Human-readable fatal error: retry button up front, raw cause tucked away. */
+function FatalError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="my-6">
+      <p className="error">
+        Failed to load the dashboard data. This is usually temporary — try again in a moment.
+      </p>
+      <button type="button" className="dl mt-2" onClick={onRetry}>
+        Retry
+      </button>
+      <details className="mt-3 text-[13px] text-muted">
+        <summary className="cursor-pointer">Error details</summary>
+        <pre className="mt-2 whitespace-pre-wrap break-all">{message}</pre>
+      </details>
+    </div>
+  );
+}
 
-  useEffect(() => {
-    fetchManifest().then(setManifest).catch((cause: unknown) => setError(String(cause)));
-  }, []);
-
-  if (error) {
-    return <p className="error">Failed to load the data API: {error}</p>;
-  }
-  if (!manifest) {
-    return <p className="sub">Loading…</p>;
-  }
-
+/** Everything that depends on a loaded manifest — tabs, org filter, panels, footer. */
+function Dashboard({
+  manifest,
+  macro,
+  setMacro,
+  org,
+  setOrg,
+}: {
+  manifest: Manifest;
+  macro: string;
+  setMacro: (value: string) => void;
+  org: string;
+  setOrg: (value: string) => void;
+}) {
   const orgs = Object.keys(manifest.orgs);
   const derived = [
     ...new Set(
@@ -152,8 +168,7 @@ export default function App() {
   const glossary = orgHasMacro ? manifest.macro_glossaries?.[activeMacro] : undefined;
 
   return (
-    <div className="wrap">
-      <h1>Hiero — analytics dashboard</h1>
+    <>
       <p className="sub">
         Generated {stamp(manifest.generated_at)} UTC · every table filters and sorts · click a chart to enlarge.
       </p>
@@ -183,6 +198,53 @@ export default function App() {
         {manifest.wip !== false && <WipFooter issuesUrl={manifest.issues_url} />}
         <ProvenanceFooter provenance={manifest.provenance} />
       </div>
+    </>
+  );
+}
+
+export default function App() {
+  const [manifest, setManifest] = useState<Manifest | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  // Bumped by retry to re-run the fetch below without duplicating its body.
+  const [reloadKey, setReloadKey] = useState(0);
+  const [macro, setMacro] = useHashState("tab", "");
+  const [org, setOrg] = useHashState("org", "");
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    fetchManifest()
+      .then((data) => {
+        if (!cancelled) setManifest(data);
+      })
+      .catch((cause: unknown) => {
+        if (!cancelled) setError(String(cause));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const retry = () => {
+    setManifest(null);
+    setReloadKey((key) => key + 1);
+  };
+
+  return (
+    <div className="wrap">
+      <h1>Hiero — analytics dashboard</h1>
+      {/* The header renders in every state below; only the content beneath it
+          changes shape — chrome never pops in after the fact. */}
+      {error ? (
+        <FatalError message={error} onRetry={retry} />
+      ) : !manifest ? (
+        <>
+          <p className="sub">Loading…</p>
+          <Skeleton label="Loading dashboard" rows={5} />
+        </>
+      ) : (
+        <Dashboard manifest={manifest} macro={macro} setMacro={setMacro} org={org} setOrg={setOrg} />
+      )}
     </div>
   );
 }

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -28,6 +28,7 @@ export const VIRTUALIZE_ABOVE = 100;
 export function DataTable({ table }: { table: Table<Row> }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const rows = table.getRowModel().rows;
+  const globalFilter = (table.getState().globalFilter as string) ?? "";
   const virtualized = rows.length > VIRTUALIZE_ABOVE;
   const virtualizer = useVirtualizer({
     count: virtualized ? rows.length : 0,
@@ -50,7 +51,7 @@ export function DataTable({ table }: { table: Table<Row> }) {
         className="search"
         placeholder="Filter…"
         aria-label="Filter rows"
-        value={(table.getState().globalFilter as string) ?? ""}
+        value={globalFilter}
         onChange={(event) => table.setGlobalFilter(event.target.value)}
       />
       <div className="tablewrap" ref={scrollRef}>
@@ -82,6 +83,22 @@ export function DataTable({ table }: { table: Table<Row> }) {
             ))}
           </thead>
           <tbody>
+            {rows.length === 0 && (
+              <tr>
+                <td colSpan={columnCount} className="py-6 text-center text-[13px] text-muted">
+                  {globalFilter ? (
+                    <>
+                      No rows match —{" "}
+                      <button type="button" className="underline" onClick={() => table.setGlobalFilter("")}>
+                        clear the filter?
+                      </button>
+                    </>
+                 ) : (
+                  "No rows to show."
+                   )}
+                 </td>
+               </tr>
+             )}
             {paddingTop > 0 && (
               <tr aria-hidden="true">
                 <td colSpan={columnCount} style={{ height: paddingTop, padding: 0, border: 0 }} />

--- a/web/src/components/Skeleton.tsx
+++ b/web/src/components/Skeleton.tsx
@@ -1,0 +1,21 @@
+/**
+ * A stateless placeholder standing in for content that hasn't arrived yet —
+ * used both for the very first manifest fetch and for a tab switch, so
+ * loading always reads the same rather than flickering between shapes.
+ */
+
+export function Skeleton({ label, rows = 4 }: { label: string; rows?: number }) {
+  return (
+    <div role="status" aria-live="polite" aria-label={label} className="my-3">
+      <div aria-hidden="true" className="flex flex-col gap-2">
+        {Array.from({ length: rows }, (_, index) => (
+          <div
+            key={index}
+            className="h-[27px] animate-pulse rounded bg-raise"
+            style={{ width: `${85 - index * 6}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -301,3 +301,79 @@ describe("Section groups", () => {
     expect(window.location.hash).not.toContain("grp-");
   });
 });
+
+describe("Loading, empty-filter, and error states (#343)", () => {
+  it("shows the header and an initial-load placeholder before the manifest arrives", async () => {
+    vi.unstubAllGlobals();
+    let resolveManifest!: (response: Response) => void;
+    const pending = new Promise<Response>((resolve) => {
+      resolveManifest = resolve;
+    });
+    const { MANIFEST } = await import("./fixtures");
+    stubApi({ "manifest.json": () => pending });
+
+    render(<App />);
+
+    expect(screen.getByRole("heading", { name: "Hiero — analytics dashboard" })).toBeInTheDocument();
+    expect(screen.getByRole("status", { name: "Loading dashboard" })).toBeInTheDocument();
+
+    resolveManifest(new Response(JSON.stringify(MANIFEST)));
+    expect(await screen.findByRole("button", { name: "Governance" })).toBeInTheDocument();
+    expect(screen.queryByRole("status", { name: "Loading dashboard" })).not.toBeInTheDocument();
+  });
+
+  it("shows a tab-switch skeleton while a section is still fetching", async () => {
+    vi.unstubAllGlobals();
+    let resolveRoles!: (response: Response) => void;
+    const pendingRoles = new Promise<Response>((resolve) => {
+      resolveRoles = resolve;
+    });
+    const { GOV_DOC } = await import("./fixtures");
+    stubApi({ "roles.json": () => pendingRoles });
+
+    render(<App />);
+    await userEvent.click(await screen.findByRole("button", { name: "Governance" }));
+
+    expect(screen.getByRole("status", { name: "Loading tab" })).toBeInTheDocument();
+    expect(screen.queryByText("Role holders")).not.toBeInTheDocument();
+
+    resolveRoles(new Response(JSON.stringify(GOV_DOC)));
+    expect(await screen.findByText("Role holders")).toBeInTheDocument();
+    expect(screen.queryByRole("status", { name: "Loading tab" })).not.toBeInTheDocument();
+  });
+
+  it("shows a no-matches message when a filter excludes every row, and clears it", async () => {
+    await openGovernance();
+
+    await userEvent.type(screen.getByPlaceholderText("Filter…"), "nobody-has-this-name");
+    expect(await screen.findByText(/No rows match/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "clear the filter?" })).toBeInTheDocument();
+    expect(screen.queryByText("alice")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "clear the filter?" }));
+    expect(await screen.findByText("alice")).toBeInTheDocument();
+    expect(screen.queryByText(/No rows match/)).not.toBeInTheDocument();
+  });
+
+  it("shows a fatal error with a retry button when the manifest fails to load", async () => {
+    vi.unstubAllGlobals();
+    const { MANIFEST } = await import("./fixtures");
+    let attempt = 0;
+    stubApi({
+      "manifest.json": () => {
+        attempt += 1;
+        return attempt === 1 ? new Response("nope", { status: 500 }) : new Response(JSON.stringify(MANIFEST));
+      },
+    });
+
+    render(<App />);
+
+    expect(screen.getByRole("heading", { name: "Hiero — analytics dashboard" })).toBeInTheDocument();
+    expect(await screen.findByText(/Failed to load the dashboard data/)).toBeInTheDocument();
+    expect(screen.getByText("Error details")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByRole("button", { name: "Governance" })).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to load the dashboard data/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -305,12 +305,21 @@ const ROUTES: Record<string, unknown> = {
   "hiero-hackers/profiles.json": HACKERS_DOC,
 };
 
-/** Stub global fetch to serve the fixture API; returns the spy for assertions. */
-export function stubApi() {
+/**
+ * Stub global fetch to serve the fixture API; returns the spy for assertions.
+ * `overrides` lets a test intercept specific routes (e.g. to delay or fail a
+ * request) while every other route still serves its normal fixture — so a
+ * test controlling one request doesn't have to also know every other request
+ * the page happens to make.
+ */
+export function stubApi(overrides: Record<string, () => Response | Promise<Response>> = {}) {
   return vi.stubGlobal(
     "fetch",
     vi.fn(async (url: string) => {
-      const match = Object.entries(ROUTES).find(([suffix]) => String(url).endsWith(suffix));
+      const key = String(url);
+      const override = Object.entries(overrides).find(([suffix]) => key.endsWith(suffix));
+      if (override) return override[1]();
+      const match = Object.entries(ROUTES).find(([suffix]) => key.endsWith(suffix));
       if (!match) {
         return new Response("not found", { status: 404 });
       }


### PR DESCRIPTION
Description. 

Turns the chart lightbox into a proper modal instead of just an overlay with an Esc listener. Focus now moves into the dialog when it opens and goes back to whatever you clicked when it closes, and Tab no longer escapes out to the page behind it. Also wired up left/right arrows to flip between chart variants (year/month etc.) while it's open, since the tabs for that were already there but you had to close the lightbox to use them.

KPI tile explanations don't have variants so arrows just do nothing there, as expected.

Related issue(s):

Fixes #329