### PR TITLE
Fix network plot layout

### DIFF
--- a/src/hiero_analytics/plotting/network.py
+++ b/src/hiero_analytics/plotting/network.py
@@ -198,7 +198,7 @@ def render_comembership_network(
             color=MUTED_TEXT_COLOR,
         )
         ax.axis("off")
-        fig.tight_layout()
+        # tight_layout conflicts with the externally positioned legend and footer.
 
         # Nodes, not edges: the node count is what a reader checks the stamp
         # against ("are all the teams here?"), and edges follow from it.


### PR DESCRIPTION
### Description
This fixes the network plot layout by removing the tight_layout() call from the comembership network rendering.

The network plot uses an externally positioned legend and footer, and tight_layout() can interfere with their positioning. Removing it allows the existing export handling to determine the final figure bounds correctly.

Closes: #317 