### PR TITLE
fix: declare color-scheme so native UI follows dark mode

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -19,6 +19,8 @@
 /* ---- Semantic palette ---------------------------------------------------- */
 
 :root {
+  color-scheme: light dark;
+
   --page: #fafafa; /* page background */
   --ink: #1b1b1b; /* primary text */
   --muted: #666; /* secondary text */


### PR DESCRIPTION
## Summary
- Declares `color-scheme: light dark;` on `:root` in `web/src/app.css`, alongside the existing token block, so the browser renders native UI (scrollbars, form controls, `<details>` disclosure triangles) in the matching scheme instead of always defaulting to light.
- Fixes the bright/light scrollbar tracks around `.tablewrap` and `.hipmx-wrap` that showed up against the dark page background when `prefers-color-scheme: dark` restyled the app's own elements but left native chrome unaffected.

## Verificationn
- `npm test`, `npm run lint`, annd `npm run build` all pass in `web/`.
- Since this repo's dev server needs the generated data API (`outputs/`) which isn't present in a fresh checkout, I verified the fix directly against the compiled stylesheet with a headless-Chromium check emulating `prefers-color-scheme: dark`:
  - `getComputedStyle(document.documentElement).colorScheme` is `"normal"` before the change and `"light dark"` after.
  - Native controls (checkbox, range slider) that are governed by the same `color-scheme` mechanism as scrollbars visibly switch from light to dark chrome once the property is declared — same effect the issue describes for `.tablewrap` / `.hipmx-wrap` scrollbars and `<details>` markers
