### PR TITLE
test: add network tight_layout regression test

### DIFF
--- a/tests/plotting/test_network.py
+++ b/tests/plotting/test_network.py
@@ -25,3 +25,37 @@ def test_renders_png(tmp_path):
     empty = tmp_path / "none.png"
     assert render_comembership_network(pd.DataFrame(), edges, empty, title="t", member_label="x") is False
     assert not empty.exists()
+
+
+def test_does_not_call_tight_layout(monkeypatch, tmp_path):
+    """Network renderer must not call tight_layout()."""
+    nodes = pd.DataFrame(
+        [
+            {"repo": "hiero-sdk-python", "active_members": 3, "total_members": 4},
+            {"repo": "hiero-consensus-node", "active_members": 1, "total_members": 2},
+            {"repo": "governance", "active_members": 2, "total_members": 2},
+        ]
+    )
+    edges = pd.DataFrame([{"repo_a": "hiero-sdk-python", "repo_b": "governance", "shared": 2}])
+
+    def fail_tight_layout(*args, **kwargs):
+        raise AssertionError("tight_layout() should not be called")
+
+    monkeypatch.setattr(
+        "matplotlib.figure.Figure.tight_layout",
+        fail_tight_layout,
+    )
+
+    output = tmp_path / "network.png"
+
+    assert (
+        render_comembership_network(
+            nodes,
+            edges,
+            output,
+            title="t",
+            member_label="x",
+        )
+        is True
+    )
+    assert output.exists()


### PR DESCRIPTION
**Description**

Add a regression test to ensure the network chart renderer does not reintroduce `fig.tight_layout()`, which previously caused layout issues with the externally positioned legend and provenance footer.

* Add a regression test that fails if `Figure.tight_layout()` is called
* Verify the network chart still renders successfully and produces the expected PNG
* Keep the regression coverage alongside the existing network plotting tests

**Related issue(s):**

Fixes #

**Notes for reviewer:**

This is a follow-up to #400. The production fix is already merged; this PR adds a focused regression guard so `fig.tight_layout()` cannot be accidentally added back later.

The test monkeypatches `matplotlib.figure.Figure.tight_layout` to raise an error if called, then renders a representative network chart and verifies that the PNG is created successfully.

**Checklist**

* [ ] I claimed the linked issue with `/assign` before starting
* [x] `uv run pytest -q tests/plotting/test_network.py --no-cov` passes locally (`2 passed`)
* [x] Tests added/updated for the change
* [x] Commits are signed and signed-off: `git commit -S -s`
* [ ] Docs updated if relevant
