### PR TITLE
feat: add pipeline list command

### DIFF
--- a/src/hiero_analytics/cli.py
+++ b/src/hiero_analytics/cli.py
@@ -39,7 +39,7 @@ def _build_parser() -> argparse.ArgumentParser:
         description="Run `hiero-analytics <command> --help` for specific subcommand options.",
         metavar="<command>",
     )
-
+    subparsers.add_parser("list", help="List all registered analytics pipelines")
     all_parser = subparsers.add_parser("all", help="Run the full suite of analytics pipelines (the default)")
     all_parser.add_argument(
         "--fail-fast",
@@ -63,6 +63,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         # Bare `hiero-analytics` has no --fail-fast; only the explicit `all` subcommand does.
         fail_fast = getattr(args, "fail_fast", False)
         run_all.main(fail_fast=fail_fast)  # does its own logging setup; exits non-zero on any failure
+        return 0
+
+    if command == "list":
+        for pipeline in PIPELINES:
+            marker = " [CLI-only]" if not pipeline.in_default_run else ""
+            print(f"{pipeline.name:<24} {pipeline.description}{marker}")
         return 0
 
     pipeline = PIPELINES_BY_NAME[command]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,6 +28,16 @@ def test_unknown_command_exits_with_error():
         cli.main(["not-a-pipeline"])
 
 
+def test_cli_lists_registered_pipelines(capsys):
+    """The list command prints registered pipeline names and returns success."""
+    assert cli.main(["list"]) == 0
+
+    output = capsys.readouterr().out
+    assert "difficulty" in output
+    assert "discord_analytics" in output
+    assert "[CLI-only]" in output
+
+
 def test_cli_runs_single_pipeline_and_forwards_options(monkeypatch):
     """A subcommand runs its pipeline, forwarding explicitly set options."""
     calls = []


### PR DESCRIPTION
## Description

Add a new `list` command to the Hiero Analytics CLI.

This makes it easier to see which analytics pipelines are available and which ones are not included in the default `all` run.

* Add the `list` command to the CLI
* Show each pipeline's name and description
* Mark CLI-only pipelines with `[CLI-only]`
* Add a test for the new command

**Related issue(s):**

Fixes #323

**Notes for reviewer:**

Running `hiero-analytics list` now shows all registered pipelines without running them or accessing the network.

**Verification:**

- `uv run pytest` — 725 passed
- `uv run ruff check src tests` — passed
- Commits are signed and signed-off

**Checklist**

- [x] I claimed the linked issue with `/assign` before starting
- [x] `uv run pytest` and `uv run ruff check src tests` pass locally
- [x] Tests added/updated for the change
- [x] Commits are signed and signed-off: `git commit -S -s`
- [x] Docs updated if relevant