### PR TITLE
Add warning for truncated PR review history

### DIFF
--- a/src/hiero_analytics/data_sources/models.py
+++ b/src/hiero_analytics/data_sources/models.py
@@ -403,8 +403,7 @@ class ContributorActivityRecord(BaseRecord):
             # The reviews connection caps results at 100 and does not paginate
             # the inner connection. Surface when a PR exceeds that limit.
             logger.warning(
-                "PR %s#%s has >100 reviews; only the first 100 were "
-                "fetched (review history truncated for this PR)",
+                "PR %s#%s has >100 reviews; only the first 100 were fetched (review history truncated for this PR)",
                 repo_name,
                 pr_number,
             )

--- a/src/hiero_analytics/data_sources/models.py
+++ b/src/hiero_analytics/data_sources/models.py
@@ -398,7 +398,18 @@ class ContributorActivityRecord(BaseRecord):
                 )
             )
 
-        for review in (node.get("reviews") or {}).get("nodes") or []:
+        reviews = node.get("reviews") or {}
+        if (reviews.get("pageInfo") or {}).get("hasNextPage"):
+            # The reviews connection caps results at 100 and does not paginate
+            # the inner connection. Surface when a PR exceeds that limit.
+            logger.warning(
+                "PR %s#%s has >100 reviews; only the first 100 were "
+                "fetched (review history truncated for this PR)",
+                repo_name,
+                pr_number,
+            )
+
+        for review in reviews.get("nodes") or []:
             review_author = _extract_login(review)
             reviewed_at = _parse_dt(review.get("submittedAt"))
             if reviewed_at and (cutoff is None or reviewed_at >= cutoff) and review_author:

--- a/src/hiero_analytics/data_sources/queries/contributor_activity.graphql
+++ b/src/hiero_analytics/data_sources/queries/contributor_activity.graphql
@@ -21,6 +21,9 @@ query CONTRIBUTOR_ACTIVITY_QUERY($owner:String!, $repo:String!, $cursor:String) 
           login
         }
         reviews(first:100) {
+          pageInfo {
+            hasNextPage
+          }
           nodes {
             state
             submittedAt

--- a/tests/data_sources/test_models.py
+++ b/tests/data_sources/test_models.py
@@ -244,9 +244,7 @@ def test_issue_timeline_event_from_issue_node_expands_timeline_items():
         },
     }
 
-    records = IssueTimelineEventRecord.from_github_node(
-        node, {"owner": "org", "repo": "repo"}
-    )
+    records = IssueTimelineEventRecord.from_github_node(node, {"owner": "org", "repo": "repo"})
 
     assert [(r.event_type, r.label) for r in records] == [
         ("labeled", "beginner"),  # event type and label name lower-cased
@@ -262,9 +260,7 @@ def test_issue_timeline_event_from_github_node_handles_empty():
     """An issue with no label events yields no records."""
     node = {"number": 7, "timelineItems": {"nodes": []}}
 
-    records = IssueTimelineEventRecord.from_github_node(
-        node, {"owner": "org", "repo": "repo"}
-    )
+    records = IssueTimelineEventRecord.from_github_node(node, {"owner": "org", "repo": "repo"})
 
     assert records == []
 
@@ -273,12 +269,7 @@ def test_hydration_tolerates_null_connections():
     """GraphQL nulls a connection on partial errors, which must not raise."""
     context = {"owner": "org", "repo": "repo", "target_type": "pull_request"}
 
-    assert (
-        IssueTimelineEventRecord.from_github_node(
-            {"number": 7, "timelineItems": None}, context
-        )
-        == []
-    )
+    assert IssueTimelineEventRecord.from_github_node({"number": 7, "timelineItems": None}, context) == []
     node = {"number": 7, "createdAt": None, "author": None, "reviews": None}
     assert ContributorActivityRecord.from_github_node(node, context) == []
 
@@ -380,9 +371,7 @@ def test_extract_labels_degrades_on_missing_or_malformed():
     """Missing labels, non-mapping entries, and non-str names are skipped."""
     assert _extract_labels({}) == []
     assert _extract_labels(None) == []
-    assert _extract_labels(
-        {"labels": {"nodes": ["x", {"name": 5}, {"name": "ok"}]}}
-    ) == ["ok"]
+    assert _extract_labels({"labels": {"nodes": ["x", {"name": 5}, {"name": "ok"}]}}) == ["ok"]
 
 
 def test_extract_label_name_lowercases():

--- a/tests/data_sources/test_models.py
+++ b/tests/data_sources/test_models.py
@@ -1,5 +1,6 @@
 """Tests for normalized GitHub data record models."""
 
+import logging
 from dataclasses import FrozenInstanceError
 from datetime import datetime
 
@@ -159,6 +160,51 @@ def test_contributor_activity_record_from_issue_node():
     ]
 
 
+def test_contributor_activity_warns_when_reviews_are_truncated(caplog):
+    """Contributor activity should warn when a PR has more than 100 reviews."""
+    node = {
+        "number": 42,
+        "createdAt": "2024-01-02T00:00:00Z",
+        "author": {"login": "dana"},
+        "reviews": {
+            "pageInfo": {"hasNextPage": True},
+            "nodes": [],
+        },
+    }
+    context = {
+        "owner": "org",
+        "repo": "repo",
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hiero_analytics.data_sources.models"):
+        ContributorActivityRecord.from_github_node(node, context)
+
+    assert len(caplog.records) == 1
+    assert "org/repo#42" in caplog.records[0].message
+
+
+def test_contributor_activity_does_not_warn_when_reviews_are_not_truncated(caplog):
+    """Contributor activity should not warn when all reviews were fetched."""
+    node = {
+        "number": 42,
+        "createdAt": "2024-01-02T00:00:00Z",
+        "author": {"login": "dana"},
+        "reviews": {
+            "pageInfo": {"hasNextPage": False},
+            "nodes": [],
+        },
+    }
+    context = {
+        "owner": "org",
+        "repo": "repo",
+    }
+
+    with caplog.at_level(logging.WARNING, logger="hiero_analytics.data_sources.models"):
+        ContributorActivityRecord.from_github_node(node, context)
+
+    assert not caplog.records
+
+
 def test_issue_timeline_event_record_creation():
     """Issue timeline records should preserve normalized event metadata."""
     occurred = datetime(2024, 1, 1)
@@ -198,7 +244,9 @@ def test_issue_timeline_event_from_issue_node_expands_timeline_items():
         },
     }
 
-    records = IssueTimelineEventRecord.from_github_node(node, {"owner": "org", "repo": "repo"})
+    records = IssueTimelineEventRecord.from_github_node(
+        node, {"owner": "org", "repo": "repo"}
+    )
 
     assert [(r.event_type, r.label) for r in records] == [
         ("labeled", "beginner"),  # event type and label name lower-cased
@@ -214,7 +262,9 @@ def test_issue_timeline_event_from_github_node_handles_empty():
     """An issue with no label events yields no records."""
     node = {"number": 7, "timelineItems": {"nodes": []}}
 
-    records = IssueTimelineEventRecord.from_github_node(node, {"owner": "org", "repo": "repo"})
+    records = IssueTimelineEventRecord.from_github_node(
+        node, {"owner": "org", "repo": "repo"}
+    )
 
     assert records == []
 
@@ -223,7 +273,12 @@ def test_hydration_tolerates_null_connections():
     """GraphQL nulls a connection on partial errors, which must not raise."""
     context = {"owner": "org", "repo": "repo", "target_type": "pull_request"}
 
-    assert IssueTimelineEventRecord.from_github_node({"number": 7, "timelineItems": None}, context) == []
+    assert (
+        IssueTimelineEventRecord.from_github_node(
+            {"number": 7, "timelineItems": None}, context
+        )
+        == []
+    )
     node = {"number": 7, "createdAt": None, "author": None, "reviews": None}
     assert ContributorActivityRecord.from_github_node(node, context) == []
 
@@ -325,7 +380,9 @@ def test_extract_labels_degrades_on_missing_or_malformed():
     """Missing labels, non-mapping entries, and non-str names are skipped."""
     assert _extract_labels({}) == []
     assert _extract_labels(None) == []
-    assert _extract_labels({"labels": {"nodes": ["x", {"name": 5}, {"name": "ok"}]}}) == ["ok"]
+    assert _extract_labels(
+        {"labels": {"nodes": ["x", {"name": 5}, {"name": "ok"}]}}
+    ) == ["ok"]
 
 
 def test_extract_label_name_lowercases():


### PR DESCRIPTION
**Description**:

This PR fixes the issue where we silently lose reviews when a pull request has more than 100 reviews. GitHub only returns the first 100 reviews, so this change detects when there are more and logs a warning.

* Check `hasNextPage` for the reviews connection
* Log a warning when a PR has more than 100 reviews
* Add tests to make sure the warning appears when needed and stays silent otherwise

**Related issue(s)**:

Fixes #416

**Notes for reviewer**:

This doesn't add pagination for the reviews yet. It just makes the truncation visible, which is what issue #416 asks for.

I ran the full test suite and lint checks locally:

* `uv run pytest` — 743 passed
* `uv run ruff check src tests` — passed
* `git diff --check` — passed

**Checklist**

- [x] I claimed the linked issue with `/assign` before starting
- [x] `uv run pytest` and `uv run ruff check src tests` pass locally
- [x] Tests added/updated for the change
- [x] Commits are signed and signed-off: `git commit -S -s`
- [ ] Docs updated if relevant