### PR TITLE
feat: wire oxlint into CI and add Prettier for web/

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,3 +49,35 @@ jobs:
       - name: Run Pyright (report-only)
         continue-on-error: true
         run: uv run pyright
+
+  web-lint:
+    name: Web Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+
+      - name: Run oxlint
+        working-directory: web
+        run: npm run lint
+
+      - name: Run Prettier Format Check
+        working-directory: web
+        run: npm run format:check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,6 +125,15 @@ Ruff's rules and line length live in [pyproject.toml](pyproject.toml) under
 `[tool.ruff]`; the same config backs the CLI, the pre-commit hook, and CI, so all
 three agree.
 
+The `web/` dashboard has its own lint/format gate, enforced by the same CI
+workflow's `web-lint` job:
+
+```bash
+npm --prefix web run lint            # oxlint (ESLint-compatible, TS/React rules)
+npm --prefix web run format:check    # Prettier
+npm --prefix web run format          # Prettier, autofix
+```
+
 ## Testing
 
 - Tests mirror the source layout: code in `src/hiero_analytics/<pkg>/<module>.py`

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,0 +1,4 @@
+dist
+dist-ssr
+coverage
+package-lock.json

--- a/web/.prettierrc.json
+++ b/web/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/web/README.md
+++ b/web/README.md
@@ -5,9 +5,9 @@ A static Vite + React + TypeScript app that renders the versioned JSON data API
 sections, chart sections, bespoke views, and metrics the API lists, so adding
 analytics on the Python side rarely requires frontend changes.
 
-Three kinds of content arrive from the API. *Sections* are tables, rendered
-generically from their column specs. *Chart sections* are PNG galleries with
-their notes and step-by-step methodology. *Views* are the bespoke cases a table
+Three kinds of content arrive from the API. _Sections_ are tables, rendered
+generically from their column specs. _Chart sections_ are PNG galleries with
+their notes and step-by-step methodology. _Views_ are the bespoke cases a table
 cannot express — today the HIP coverage matrix and governance board — which the
 Python side ships as pure data (`export/hip_views.py`) so the component owns
 only the rendering.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -25,6 +25,7 @@
         "@vitejs/plugin-react": "^6.0.5",
         "jsdom": "^30.0.1",
         "oxlint": "^1.79.0",
+        "prettier": "^3.6.2",
         "typescript": "~7.0.2",
         "vite": "^8.2.1",
         "vitest": "^4.1.11"
@@ -508,9 +509,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -528,9 +526,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -548,9 +543,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -568,9 +560,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -588,9 +577,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -608,9 +594,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -628,9 +611,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -648,9 +628,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -815,9 +792,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -833,9 +807,6 @@
       "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -853,9 +824,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -871,9 +839,6 @@
       "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -891,9 +856,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -909,9 +871,6 @@
       "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2982,6 +2941,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "oxlint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "vitest run",
     "preview": "vite preview"
   },
@@ -31,6 +33,7 @@
     "@vitejs/plugin-react": "^6.0.5",
     "jsdom": "^30.0.1",
     "oxlint": "^1.79.0",
+    "prettier": "^3.6.2",
     "typescript": "~7.0.2",
     "vite": "^8.2.1",
     "vitest": "^4.1.11"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,23 +4,22 @@
  * groups, chart-section cards, then the table sections.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { fetchManifest, type ChartSection, type Manifest } from "./api";
-import { ChartSectionCard } from "./components/ChartSectionCard";
-import { Glossary } from "./components/Glossary";
-import { MetricTiles } from "./components/MetricTiles";
-import { ProvenanceFooter } from "./components/ProvenanceFooter";
-import { SectionGroups, type Group } from "./components/SectionGroups";
-import { SectionTable } from "./components/SectionTable";
-import { Skeleton } from "./components/Skeleton";
-import { TabBar } from "./components/TabBar";
-import { WipFooter } from "./components/WipFooter";
-import { stamp } from "./format";
-import { useHashState } from "./useHashState";
-import { useSectionDocs } from "./useSectionDocs";
-import { useViewDocs } from "./useViewDocs";
-import { ViewCards } from "./components/ViewCards";
-
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { fetchManifest, type ChartSection, type Manifest } from './api';
+import { ChartSectionCard } from './components/ChartSectionCard';
+import { Glossary } from './components/Glossary';
+import { MetricTiles } from './components/MetricTiles';
+import { ProvenanceFooter } from './components/ProvenanceFooter';
+import { SectionGroups, type Group } from './components/SectionGroups';
+import { SectionTable } from './components/SectionTable';
+import { Skeleton } from './components/Skeleton';
+import { TabBar } from './components/TabBar';
+import { WipFooter } from './components/WipFooter';
+import { stamp } from './format';
+import { useHashState } from './useHashState';
+import { useSectionDocs } from './useSectionDocs';
+import { useViewDocs } from './useViewDocs';
+import { ViewCards } from './components/ViewCards';
 
 const FLASH_MS = 1800; // shared link jump: flash the target for this long, then remove the highlight
 
@@ -41,7 +40,7 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
   const chartSections = (entry.chart_sections ?? []).filter((section) => section.macro === macro);
   const provenance = manifest.provenance;
   // A shared section link names its target here; see the effect below.
-  const [widget] = useHashState("widget", "");
+  const [widget] = useHashState('widget', '');
 
   // The tab is a sequence of named sections: each group renders its views,
   // then its chart cards, then its tables, and the jump bar links each one —
@@ -60,7 +59,7 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
     if (!names.includes(chartGroup(section))) names.push(chartGroup(section));
   }
   for (const doc of docs) {
-    if (!names.includes(doc.group || "")) names.push(doc.group || "");
+    if (!names.includes(doc.group || '')) names.push(doc.group || '');
   }
   const settled = !viewsLoading && !docsLoading;
   // A shared #widget=<section id> link: once the tab settles, scroll to and flash that section
@@ -69,20 +68,20 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
     if (!settled || !widget) return;
     const jump = () => {
       const target = document.getElementById(widget);
-      target?.scrollIntoView({ block: "start", behavior: "smooth" });
-      target?.classList.add("flash");
+      target?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      target?.classList.add('flash');
       if (flashTimer.current) window.clearTimeout(flashTimer.current);
-      flashTimer.current = window.setTimeout(() => target?.classList.remove("flash"), FLASH_MS);
+      flashTimer.current = window.setTimeout(() => target?.classList.remove('flash'), FLASH_MS);
     };
-    const canRequestFrame = typeof window.requestAnimationFrame === "function";
+    const canRequestFrame = typeof window.requestAnimationFrame === 'function';
     const raf = canRequestFrame ? window.requestAnimationFrame(jump) : undefined;
     if (raf === undefined) jump();
     return () => {
-      if (typeof window.cancelAnimationFrame === "function" && raf !== undefined) {
+      if (typeof window.cancelAnimationFrame === 'function' && raf !== undefined) {
         window.cancelAnimationFrame(raf as number);
       }
       if (flashTimer.current) window.clearTimeout(flashTimer.current);
-      document.getElementById(widget)?.classList.remove("flash");
+      document.getElementById(widget)?.classList.remove('flash');
     };
   }, [settled, widget]);
   const groups: Group[] = !settled
@@ -90,7 +89,7 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
     : names.flatMap((name): Group[] => {
         const groupViews = views.filter((view) => (view.group ?? names[0]) === name);
         const groupCharts = chartSections.filter((section) => chartGroup(section) === name);
-        const groupDocs = docs.filter((doc) => (doc.group || "") === name);
+        const groupDocs = docs.filter((doc) => (doc.group || '') === name);
         if (!groupViews.length && !groupCharts.length && !groupDocs.length) return [];
         return [
           [
@@ -103,7 +102,12 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
                 <ChartSectionCard key={section.id} section={section} provenance={provenance} />
               ))}
               {groupDocs.map((doc) => (
-                <SectionTable key={doc.id} doc={doc} provenance={provenance} periodLabels={manifest.period_labels} />
+                <SectionTable
+                  key={doc.id}
+                  doc={doc}
+                  provenance={provenance}
+                  periodLabels={manifest.period_labels}
+                />
               ))}
             </>,
           ],
@@ -117,8 +121,8 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
           the tab — the rest of the page is still worth reading. */}
       {unavailable.length > 0 && (
         <p className="error">
-          Could not load {unavailable.length === 1 ? "this section" : "these sections"}:{" "}
-          {unavailable.join(", ")}. Everything else on this tab is unaffected — reload to try again.
+          Could not load {unavailable.length === 1 ? 'this section' : 'these sections'}:{' '}
+          {unavailable.join(', ')}. Everything else on this tab is unaffected — reload to try again.
         </p>
       )}
       {settled ? <SectionGroups groups={groups} /> : <Skeleton label="Loading tab" rows={6} />}
@@ -197,7 +201,8 @@ function Dashboard({
   return (
     <>
       <p className="sub">
-        Generated {stamp(manifest.generated_at)} UTC · every table filters and sorts · click a chart to enlarge.
+        Generated {stamp(manifest.generated_at)} UTC · every table filters and sorts · click a chart
+        to enlarge.
       </p>
       {/* The org filter is the outermost scope — everything below it is "this
           org's view" — so it sits above the content tabs. */}
@@ -208,7 +213,9 @@ function Dashboard({
         onSelect={(name) => setMacro(macros.find((candidate) => topOf(candidate) === name) ?? name)}
         kind="macro"
       />
-      {subTabs.length > 0 && <TabBar items={subTabs} active={activeMacro} onSelect={setMacro} kind="tab" />}
+      {subTabs.length > 0 && (
+        <TabBar items={subTabs} active={activeMacro} onSelect={setMacro} kind="tab" />
+      )}
       {/* Every macro ships its own explainer, listing only what that tab
           shows. It may be absent when a cached bundle meets an older manifest
           — degrade to no glossary, never a crash. */}
@@ -234,8 +241,8 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
   // Bumped by retry to re-run the fetch below without duplicating its body.
   const [reloadKey, setReloadKey] = useState(0);
-  const [macro, setMacro] = useHashState("tab", "");
-  const [org, setOrg] = useHashState("org", "");
+  const [macro, setMacro] = useHashState('tab', '');
+  const [org, setOrg] = useHashState('org', '');
 
   useEffect(() => {
     let cancelled = false;
@@ -270,7 +277,13 @@ export default function App() {
           <Skeleton label="Loading dashboard" rows={5} />
         </>
       ) : (
-        <Dashboard manifest={manifest} macro={macro} setMacro={setMacro} org={org} setOrg={setOrg} />
+        <Dashboard
+          manifest={manifest}
+          macro={macro}
+          setMacro={setMacro}
+          org={org}
+          setOrg={setOrg}
+        />
       )}
     </div>
   );

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -11,7 +11,8 @@
  * truth for the valid set. Keep the two lists in sync; a mismatch is a
  * compile-time error here and a test failure on the Python side.
  */
-export type ColumnFormat = "hip" | "date" | "link" | "evidence" | "status" | "flag" | "presence" | "number";
+export type ColumnFormat =
+  'hip' | 'date' | 'link' | 'evidence' | 'status' | 'flag' | 'presence' | 'number';
 
 export interface ColumnSpec {
   key: string;
@@ -89,7 +90,7 @@ export interface MatrixCell {
 
 /** The trailing parity note of a matrix row (e.g. which SDKs lack PRs). */
 export interface GapNote {
-  kind: "complete" | "none" | "partial";
+  kind: 'complete' | 'none' | 'partial';
   text: string;
   items?: string[];
 }
@@ -106,7 +107,7 @@ export interface MatrixRow {
 /** A generic entity x category matrix (today: HIP implementation coverage). */
 export interface MatrixView {
   id: string;
-  kind: "matrix";
+  kind: 'matrix';
   macro: string;
   /** The named section group this view renders under. */
   group?: string;
@@ -137,7 +138,7 @@ export interface BoardItem {
 /** Entities placed in lifecycle columns (today: the HIP governance board). */
 export interface BoardView {
   id: string;
-  kind: "board";
+  kind: 'board';
   macro: string;
   /** The named section group this view renders under. */
   group?: string;
@@ -231,12 +232,14 @@ async function getJson<T>(url: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-export const fetchManifest = (): Promise<Manifest> => getJson<Manifest>(`${API_ROOT}/manifest.json`);
+export const fetchManifest = (): Promise<Manifest> =>
+  getJson<Manifest>(`${API_ROOT}/manifest.json`);
 
 export const fetchSection = (ref: SectionRef): Promise<SectionDoc> =>
   getJson<SectionDoc>(`${API_ROOT}/${ref.path}`);
 
-export const fetchView = (ref: ViewRef): Promise<ViewDoc> => getJson<ViewDoc>(`${API_ROOT}/${ref.path}`);
+export const fetchView = (ref: ViewRef): Promise<ViewDoc> =>
+  getJson<ViewDoc>(`${API_ROOT}/${ref.path}`);
 
 /** Raw text of a file shipped inside the API tree (e.g. a chart's CSV). */
 export const fetchApiText = (path: string): Promise<string> =>

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -13,8 +13,8 @@
  */
 
 @layer theme, base, components, utilities;
-@import "tailwindcss/theme.css" layer(theme);
-@import "tailwindcss/utilities.css" layer(utilities);
+@import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/utilities.css' layer(utilities);
 
 /* ---- Semantic palette ---------------------------------------------------- */
 
@@ -150,7 +150,12 @@
 
 @layer base {
   body {
-    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-family:
+      system-ui,
+      -apple-system,
+      'Segoe UI',
+      Roboto,
+      sans-serif;
     max-width: 1100px;
     margin: 0 auto;
     padding: 24px;
@@ -347,7 +352,7 @@
     border-radius: var(--r-card);
     padding: 16px 18px;
     margin-bottom: 20px;
-    scroll-margin-top: var(--jump-h); 
+    scroll-margin-top: var(--jump-h);
   }
   .card.flash {
     background: var(--flash);
@@ -466,7 +471,7 @@
     display: none;
   }
   .tsum::before {
-    content: "\25B8";
+    content: '\25B8';
     color: var(--soft);
     font-size: 13px;
     transition: transform 0.15s ease;
@@ -733,7 +738,7 @@
     border-bottom: 1px solid var(--edge);
   }
   .group {
-  scroll-margin-top: var(--jump-h);
+    scroll-margin-top: var(--jump-h);
   }
   .jlabel {
     font-size: 12px;
@@ -767,7 +772,7 @@
     display: none;
   }
   summary.grouphdr::before {
-    content: "\25be";
+    content: '\25be';
     display: inline-block;
     width: 1.1em;
     color: var(--soft);
@@ -815,7 +820,7 @@
     background: var(--surface);
   }
   .chip::before {
-    content: "";
+    content: '';
     width: 7px;
     height: 7px;
     border-radius: 50%;
@@ -887,7 +892,6 @@
       filter: invert(0.9) hue-rotate(180deg);
     }
   }
-
 
   /* ---- HIP views (coverage matrix, governance board, evidence panel) ----
      Expressed through the semantic tokens like the rest of the stylesheet, so
@@ -1271,5 +1275,4 @@
   .hipboard-info button {
     margin-left: auto;
   }
-
 }

--- a/web/src/components/ChartInfo.tsx
+++ b/web/src/components/ChartInfo.tsx
@@ -6,7 +6,7 @@
  * the data API.
  */
 
-import { emphasized } from "../markup";
+import { emphasized } from '../markup';
 
 export interface ChartInfoProps {
   note?: string;

--- a/web/src/components/ChartLightbox.tsx
+++ b/web/src/components/ChartLightbox.tsx
@@ -5,8 +5,8 @@
  * step-by-step methodology on the dark background.
  */
 
-import { useEffect } from "react";
-import { ChartInfo, type ChartInfoProps } from "./ChartInfo";
+import { useEffect } from 'react';
+import { ChartInfo, type ChartInfoProps } from './ChartInfo';
 
 export interface LightboxContent extends ChartInfoProps {
   /** Absent for text-only content (a KPI tile's explanation). */
@@ -16,17 +16,29 @@ export interface LightboxContent extends ChartInfoProps {
   title?: string;
 }
 
-export function ChartLightbox({ content, onClose }: { content: LightboxContent; onClose: () => void }) {
+export function ChartLightbox({
+  content,
+  onClose,
+}: {
+  content: LightboxContent;
+  onClose: () => void;
+}) {
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === 'Escape') onClose();
     };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
 
   return (
-    <div className="lightbox" style={{ display: "flex" }} onClick={onClose} role="dialog" aria-label={content.alt}>
+    <div
+      className="lightbox"
+      style={{ display: 'flex' }}
+      onClick={onClose}
+      role="dialog"
+      aria-label={content.alt}
+    >
       <span className="hint">click outside or press Esc to close</span>
       <button type="button" className="lbclose" aria-label="Close" onClick={onClose}>
         ✕

--- a/web/src/components/ChartSectionCard.tsx
+++ b/web/src/components/ChartSectionCard.tsx
@@ -6,11 +6,11 @@
  * methodology. The PNGs carry their provenance footer in the image itself.
  */
 
-import { useState } from "react";
-import { chartUrl, fetchApiText, type ChartSection, type ChartSpec, type Manifest } from "../api";
-import { downloadCsvText } from "../csv";
-import { ChartLightbox, type LightboxContent } from "./ChartLightbox";
-import { CopyLinkButton } from "./CopyLinkButton";
+import { useState } from 'react';
+import { chartUrl, fetchApiText, type ChartSection, type ChartSpec, type Manifest } from '../api';
+import { downloadCsvText } from '../csv';
+import { ChartLightbox, type LightboxContent } from './ChartLightbox';
+import { CopyLinkButton } from './CopyLinkButton';
 
 function Figure({
   chart,
@@ -48,13 +48,13 @@ function Figure({
     />
   );
   return (
-    <figure className={slide ? "slide" : fullRow ? "chart wide" : "chart"}>
+    <figure className={slide ? 'slide' : fullRow ? 'chart wide' : 'chart'}>
       {chart.variants.length > 1 && (
         <div className="charttabs">
           {chart.variants.map((option, index) => (
             <button
               key={option.label}
-              className={index === variant ? "ctab active" : "ctab"}
+              className={index === variant ? 'ctab active' : 'ctab'}
               onClick={() => setVariant(index)}
             >
               {option.label}
@@ -73,7 +73,7 @@ export function ChartSectionCard({
   provenance,
 }: {
   section: ChartSection;
-  provenance: Manifest["provenance"];
+  provenance: Manifest['provenance'];
 }) {
   const [slide, setSlide] = useState(0);
   const [zoom, setZoom] = useState<LightboxContent | null>(null);
@@ -118,7 +118,13 @@ export function ChartSectionCard({
                   // The chart's companion table, stamped with the provenance
                   // preamble like every other browser download.
                   fetchApiText(download.path).then((text) =>
-                    downloadCsvText(download.name, section.title, text, provenance, download.generated_at),
+                    downloadCsvText(
+                      download.name,
+                      section.title,
+                      text,
+                      provenance,
+                      download.generated_at,
+                    ),
                   )
                 }
               >
@@ -141,7 +147,12 @@ export function ChartSectionCard({
               Next ›
             </button>
           </div>
-          <Figure key={section.charts[slide].title} chart={section.charts[slide]} onZoom={onZoom} slide />
+          <Figure
+            key={section.charts[slide].title}
+            chart={section.charts[slide]}
+            onZoom={onZoom}
+            slide
+          />
         </div>
       ) : (
         <div className="gallery">

--- a/web/src/components/CopyLinkButton.tsx
+++ b/web/src/components/CopyLinkButton.tsx
@@ -3,21 +3,21 @@
  * then copies it. Label flips to "Copied!" or "Couldn't copy" and reverts on its own,
  * so the click always shows feedback whether successful or not.
  */
-import { useEffect, useRef, useState } from "react";
-import { copyText, shareUrl } from "../share";
+import { useEffect, useRef, useState } from 'react';
+import { copyText, shareUrl } from '../share';
 
 const TRANSIENT_MS = 1600;
 
-type CopyStatus = "idle" | "copied" | "failed";
+type CopyStatus = 'idle' | 'copied' | 'failed';
 
 const LABELS: Record<CopyStatus, string> = {
-  idle: "Copy link",
-  copied: "Copied!",
+  idle: 'Copy link',
+  copied: 'Copied!',
   failed: "Couldn't copy",
 };
 
 export function CopyLinkButton({ sectionId }: { sectionId: string }) {
-  const [status, setStatus] = useState<CopyStatus>("idle");
+  const [status, setStatus] = useState<CopyStatus>('idle');
   const timer = useRef<number | undefined>(undefined);
   const clickId = useRef(0);
 
@@ -30,13 +30,19 @@ export function CopyLinkButton({ sectionId }: { sectionId: string }) {
     if (id !== clickId.current) return;
 
     window.clearTimeout(timer.current);
-    setStatus(ok ? "copied" : "failed");
-    timer.current = window.setTimeout(() => setStatus("idle"), TRANSIENT_MS);
+    setStatus(ok ? 'copied' : 'failed');
+    timer.current = window.setTimeout(() => setStatus('idle'), TRANSIENT_MS);
   };
 
   return (
     <button type="button" className="dl" onClick={onCopy}>
-      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+      <svg
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        aria-hidden="true"
+      >
         <path
           d="M6.2 9.8 4.5 11.5a2.1 2.1 0 0 1-3-3L4.2 5.8a2.1 2.1 0 0 1 3 0"
           strokeLinecap="round"

--- a/web/src/components/CoverageMatrix.tsx
+++ b/web/src/components/CoverageMatrix.tsx
@@ -9,10 +9,10 @@
  * sortable table.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import type { MatrixRow, MatrixView } from "../api";
-import type { EvidenceItem } from "./EvidencePanel";
-import { EvidencePanel } from "./EvidencePanel";
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { MatrixRow, MatrixView } from '../api';
+import type { EvidenceItem } from './EvidencePanel';
+import { EvidencePanel } from './EvidencePanel';
 
 /** The board's "show in matrix" request; nonce re-triggers repeat jumps. */
 export interface JumpRequest {
@@ -27,13 +27,15 @@ function cellClass(merged: number, open: number, ceilings: number[]): string {
     const bucket = ceilings.findIndex((ceiling) => merged <= ceiling);
     return bucket === -1 ? `m${ceilings.length + 1}` : `m${bucket + 1}`;
   }
-  return open > 0 ? "mo" : "m0";
+  return open > 0 ? 'mo' : 'm0';
 }
 
 /** Everything the legacy row matched its text filter against. */
 function haystack(row: MatrixRow): string {
-  const cells = row.cells.map((cell) => (cell.merged > 0 ? String(cell.merged) : cell.open > 0 ? "○" : "—"));
-  return [row.label, row.sublabel, row.status, row.note.text, ...cells].join(" ").toLowerCase();
+  const cells = row.cells.map((cell) =>
+    cell.merged > 0 ? String(cell.merged) : cell.open > 0 ? '○' : '—',
+  );
+  return [row.label, row.sublabel, row.status, row.note.text, ...cells].join(' ').toLowerCase();
 }
 
 export function CoverageMatrix({
@@ -45,8 +47,8 @@ export function CoverageMatrix({
   evidence: Map<string, EvidenceItem[]>;
   jump: JumpRequest | null;
 }) {
-  const [query, setQuery] = useState("");
-  const [status, setStatus] = useState("");
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState('');
   const [selected, setSelected] = useState<{ hip: number; repo: string } | null>(null);
   const [flashHip, setFlashHip] = useState<number | null>(null);
   const tableRef = useRef<HTMLTableElement>(null);
@@ -55,12 +57,12 @@ export function CoverageMatrix({
   // scrolls to it and flashes it — exactly the legacy behaviour.
   useEffect(() => {
     if (!jump) return;
-    setQuery("");
-    setStatus("");
+    setQuery('');
+    setStatus('');
     setSelected(null);
     setFlashHip(jump.hip);
     const row = tableRef.current?.querySelector(`#hipmx-row-${jump.hip}`);
-    row?.scrollIntoView?.({ block: "center", behavior: "smooth" });
+    row?.scrollIntoView?.({ block: 'center', behavior: 'smooth' });
     const timer = setTimeout(() => setFlashHip(null), FLASH_MS);
     return () => clearTimeout(timer);
   }, [jump]);
@@ -68,14 +70,18 @@ export function CoverageMatrix({
   const rows = useMemo(() => {
     const needle = query.trim().toLowerCase();
     return view.rows.filter(
-      (row) => (status === "" || row.status === status) && (needle === "" || haystack(row).includes(needle)),
+      (row) =>
+        (status === '' || row.status === status) &&
+        (needle === '' || haystack(row).includes(needle)),
     );
   }, [view.rows, query, status]);
 
   const selectedItems = selected ? evidence.get(`${selected.hip}|${selected.repo}`) : undefined;
 
   const toggleCell = (hip: number, repo: string) => {
-    setSelected((current) => (current && current.hip === hip && current.repo === repo ? null : { hip, repo }));
+    setSelected((current) =>
+      current && current.hip === hip && current.repo === repo ? null : { hip, repo },
+    );
   };
 
   return (
@@ -93,8 +99,8 @@ export function CoverageMatrix({
             <button
               key={option}
               type="button"
-              className={option === status ? "hipmx-fbtn active" : "hipmx-fbtn"}
-              onClick={() => setStatus((current) => (current === option ? "" : option))}
+              className={option === status ? 'hipmx-fbtn active' : 'hipmx-fbtn'}
+              onClick={() => setStatus((current) => (current === option ? '' : option))}
             >
               {option}
             </button>
@@ -125,7 +131,11 @@ export function CoverageMatrix({
           </thead>
           <tbody>
             {rows.map((row) => (
-              <tr key={row.key} id={`hipmx-row-${row.key}`} className={row.key === flashHip ? "flash" : undefined}>
+              <tr
+                key={row.key}
+                id={`hipmx-row-${row.key}`}
+                className={row.key === flashHip ? 'flash' : undefined}
+              >
                 <th>
                   {row.label}
                   <small>{row.sublabel}</small>
@@ -145,7 +155,7 @@ export function CoverageMatrix({
                   return (
                     <td
                       key={cell.key}
-                      className={`${heat} ck${isSelected ? " sel" : ""}`}
+                      className={`${heat} ck${isSelected ? ' sel' : ''}`}
                       title={
                         cell.merged > 0
                           ? `${cell.merged} merged PRs — click for the list`
@@ -154,23 +164,23 @@ export function CoverageMatrix({
                       {...(clickable && {
                         onClick: () => toggleCell(row.key, cell.key),
                         onKeyDown: (event: React.KeyboardEvent) => {
-                          if (event.key === "Enter" || event.key === " ") {
+                          if (event.key === 'Enter' || event.key === ' ') {
                             event.preventDefault();
                             toggleCell(row.key, cell.key);
                           }
                         },
                         tabIndex: 0,
-                        role: "button",
+                        role: 'button',
                       })}
                     >
-                      {cell.merged > 0 ? cell.merged : "○"}
+                      {cell.merged > 0 ? cell.merged : '○'}
                     </td>
                   );
                 })}
                 <td className="hipmx-gaps">
-                  {row.note.kind === "complete" ? (
+                  {row.note.kind === 'complete' ? (
                     <span className="ok">{row.note.text}</span>
-                  ) : row.note.kind === "none" ? (
+                  ) : row.note.kind === 'none' ? (
                     <span className="none">{row.note.text}</span>
                   ) : (
                     row.note.text
@@ -189,7 +199,8 @@ export function CoverageMatrix({
         {view.ramp.map((_shade, index) => (
           <i key={index} className={`m${index + 1}`} />
         ))}
-        more merged PRs&nbsp;&nbsp;·&nbsp;&nbsp;○ open PRs only&nbsp;&nbsp;·&nbsp;&nbsp;— no reference found
+        more merged PRs&nbsp;&nbsp;·&nbsp;&nbsp;○ open PRs only&nbsp;&nbsp;·&nbsp;&nbsp;— no
+        reference found
       </div>
       {selected && selectedItems && (
         <EvidencePanel

--- a/web/src/components/CsvDownloadButton.tsx
+++ b/web/src/components/CsvDownloadButton.tsx
@@ -1,18 +1,24 @@
 /** The "Download CSV" button — builds its payload lazily on click. */
 
-import type { Manifest } from "../api";
-import { downloadCsv, type CsvExport } from "../csv";
+import type { Manifest } from '../api';
+import { downloadCsv, type CsvExport } from '../csv';
 
 export function CsvDownloadButton({
   payload,
   provenance,
 }: {
   payload: () => CsvExport;
-  provenance: Manifest["provenance"];
+  provenance: Manifest['provenance'];
 }) {
   return (
     <button className="dl" onClick={() => downloadCsv(payload(), provenance)}>
-      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" aria-hidden="true">
+      <svg
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        aria-hidden="true"
+      >
         <path d="M8 2v8m0 0 3-3m-3 3L5 7" strokeLinecap="round" strokeLinejoin="round" />
         <path d="M2.5 11v1.5a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V11" strokeLinecap="round" />
       </svg>

--- a/web/src/components/DataTable.tsx
+++ b/web/src/components/DataTable.tsx
@@ -13,10 +13,10 @@
  * purely about what reaches the DOM.
  */
 
-import { useRef } from "react";
-import { flexRender, type Table } from "@tanstack/react-table";
-import { useVirtualizer } from "@tanstack/react-virtual";
-import type { Row } from "../api";
+import { useRef } from 'react';
+import { flexRender, type Table } from '@tanstack/react-table';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import type { Row } from '../api';
 
 // Typical rendered height of one row; the virtualiser corrects itself from
 // real measurements as rows mount, so this only has to be close.
@@ -28,7 +28,7 @@ export const VIRTUALIZE_ABOVE = 100;
 export function DataTable({ table }: { table: Table<Row> }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const rows = table.getRowModel().rows;
-  const globalFilter = (table.getState().globalFilter as string) ?? "";
+  const globalFilter = (table.getState().globalFilter as string) ?? '';
   const virtualized = rows.length > VIRTUALIZE_ABOVE;
   const virtualizer = useVirtualizer({
     count: virtualized ? rows.length : 0,
@@ -64,16 +64,24 @@ export function DataTable({ table }: { table: Table<Row> }) {
                   return (
                     <th
                       key={header.id}
-                      className={
-                        header.column.columnDef.meta?.numeric ? "num" : undefined
+                      className={header.column.columnDef.meta?.numeric ? 'num' : undefined}
+                      aria-sort={
+                        sorted === 'asc'
+                          ? 'ascending'
+                          : sorted === 'desc'
+                            ? 'descending'
+                            : undefined
                       }
-                      aria-sort={sorted === "asc" ? "ascending" : sorted === "desc" ? "descending" : undefined}
                     >
-                      <button type="button" className="thbtn" onClick={header.column.getToggleSortingHandler()}>
+                      <button
+                        type="button"
+                        className="thbtn"
+                        onClick={header.column.getToggleSortingHandler()}
+                      >
                         {flexRender(header.column.columnDef.header, header.getContext())}
                         {/* The mark's slot is always reserved so toggling sort never shifts the column. */}
                         <span className="sortmark" aria-hidden="true">
-                          {{ asc: "↑", desc: "↓" }[sorted] ?? ""}
+                          {{ asc: '↑', desc: '↓' }[sorted] ?? ''}
                         </span>
                       </button>
                     </th>
@@ -88,17 +96,21 @@ export function DataTable({ table }: { table: Table<Row> }) {
                 <td colSpan={columnCount} className="py-6 text-center text-[13px] text-muted">
                   {globalFilter ? (
                     <>
-                      No rows match —{" "}
-                      <button type="button" className="underline" onClick={() => table.setGlobalFilter("")}>
+                      No rows match —{' '}
+                      <button
+                        type="button"
+                        className="underline"
+                        onClick={() => table.setGlobalFilter('')}
+                      >
                         clear the filter?
                       </button>
                     </>
-                 ) : (
-                  "No rows to show."
-                   )}
-                 </td>
-               </tr>
-             )}
+                  ) : (
+                    'No rows to show.'
+                  )}
+                </td>
+              </tr>
+            )}
             {paddingTop > 0 && (
               <tr aria-hidden="true">
                 <td colSpan={columnCount} style={{ height: paddingTop, padding: 0, border: 0 }} />
@@ -113,7 +125,7 @@ export function DataTable({ table }: { table: Table<Row> }) {
                 {row.getVisibleCells().map((cell) => (
                   <td
                     key={cell.id}
-                    className={cell.column.columnDef.meta?.numeric ? "num" : undefined}
+                    className={cell.column.columnDef.meta?.numeric ? 'num' : undefined}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </td>
@@ -122,7 +134,10 @@ export function DataTable({ table }: { table: Table<Row> }) {
             ))}
             {paddingBottom > 0 && (
               <tr aria-hidden="true">
-                <td colSpan={columnCount} style={{ height: paddingBottom, padding: 0, border: 0 }} />
+                <td
+                  colSpan={columnCount}
+                  style={{ height: paddingBottom, padding: 0, border: 0 }}
+                />
               </tr>
             )}
           </tbody>

--- a/web/src/components/EvidencePanel.tsx
+++ b/web/src/components/EvidencePanel.tsx
@@ -4,8 +4,8 @@
  * the panel exists so each cell's count is independently checkable.
  */
 
-import { useEffect } from "react";
-import { safeUrl } from "../safety";
+import { useEffect } from 'react';
+import { safeUrl } from '../safety';
 
 /** One evidence line, in the legacy panel's field order. */
 export interface EvidenceItem {
@@ -31,10 +31,10 @@ export function EvidencePanel({
 }) {
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === 'Escape') onClose();
     };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
   }, [onClose]);
 
   return (
@@ -44,7 +44,7 @@ export function EvidencePanel({
           HIP-{hip} · {repo}
         </h3>
         <span className="n">
-          {items.length} referencing PR{items.length > 1 ? "s" : ""}
+          {items.length} referencing PR{items.length > 1 ? 's' : ''}
         </span>
         <button type="button" className="dl" onClick={onClose}>
           Close
@@ -64,8 +64,10 @@ export function EvidencePanel({
                   <span>#{item.n}</span>
                 )}
                 <span className="t">{item.t}</span>
-                <span className="meta">{item.st === "MERGED" ? `merged ${item.d}` : item.st.toLowerCase()}</span>
-                <span className="meta">matched in: {item.m.split("|").join(", ")}</span>
+                <span className="meta">
+                  {item.st === 'MERGED' ? `merged ${item.d}` : item.st.toLowerCase()}
+                </span>
+                <span className="meta">matched in: {item.m.split('|').join(', ')}</span>
                 {item.q && <span className="cue">not counted — “{item.q}”</span>}
               </div>
               {item.x && <div className="snip">{item.x}</div>}

--- a/web/src/components/FormattedCell.tsx
+++ b/web/src/components/FormattedCell.tsx
@@ -5,33 +5,33 @@
  * switches.
  */
 
-import type { ColumnFormat } from "../api";
-import { dateStamp } from "../format";
-import { safeUrl } from "../safety";
+import type { ColumnFormat } from '../api';
+import { dateStamp } from '../format';
+import { safeUrl } from '../safety';
 
 // Fixed locale: the dashboard's prose is en, and a deterministic separator
 // keeps snapshots and tests stable across viewer locales.
-const NUMBER_FORMAT = new Intl.NumberFormat("en-US");
+const NUMBER_FORMAT = new Intl.NumberFormat('en-US');
 
 export function FormattedCell({ value, format }: { value: unknown; format?: ColumnFormat }) {
-  if (value === null || value === undefined || value === "") {
+  if (value === null || value === undefined || value === '') {
     return null;
   }
   const text = String(value);
   switch (format) {
-    case "number": {
+    case 'number': {
       // Separators for legibility; a non-numeric value (older API, junk row)
       // degrades to plain text rather than NaN.
-      const numeric = typeof value === "number" ? value : Number(text);
+      const numeric = typeof value === 'number' ? value : Number(text);
       return <>{Number.isFinite(numeric) ? NUMBER_FORMAT.format(numeric) : text}</>;
     }
-    case "hip":
+    case 'hip':
       return <span className="cell-hip">HIP-{text}</span>;
-    case "date":
+    case 'date':
       // UTC-converted date, full raw timestamp on hover. Conversion, not
       // truncation: slicing an offset-bearing value can misreport the day.
       return <span title={text}>{dateStamp(text)}</span>;
-    case "link": {
+    case 'link': {
       // The href comes from generated data; an unsafe scheme renders as inert
       // text rather than a clickable link.
       const href = safeUrl(text);
@@ -43,20 +43,23 @@ export function FormattedCell({ value, format }: { value: unknown; format?: Colu
         <>{text}</>
       );
     }
-    case "evidence": {
-      const tone = text === "merged" ? "chip-merged" : text === "open_only" ? "chip-open" : "chip-none";
-      return <span className={`chip ${tone}`}>{text.replace("_", " ")}</span>;
+    case 'evidence': {
+      const tone =
+        text === 'merged' ? 'chip-merged' : text === 'open_only' ? 'chip-open' : 'chip-none';
+      return <span className={`chip ${tone}`}>{text.replace('_', ' ')}</span>;
     }
-    case "status":
+    case 'status':
       return <span className="chip chip-spec">{text}</span>;
-    case "flag":
-      return <>{text === "true" || text === "True" ? "✓" : "—"}</>;
-    case "presence": {
+    case 'flag':
+      return <>{text === 'true' || text === 'True' ? '✓' : '—'}</>;
+    case 'presence': {
       // A yes/no column: a labelled chip reads at a glance where a bare tick
       // leaves the reader decoding an empty-looking cell.
-      const present = text === "true" || text === "True";
+      const present = text === 'true' || text === 'True';
       return (
-        <span className={present ? "chip chip-merged" : "chip chip-none"}>{present ? "present" : "missing"}</span>
+        <span className={present ? 'chip chip-merged' : 'chip chip-none'}>
+          {present ? 'present' : 'missing'}
+        </span>
       );
     }
     default:

--- a/web/src/components/Glossary.tsx
+++ b/web/src/components/Glossary.tsx
@@ -4,12 +4,12 @@
  * only inline markup the glossary contract allows.
  */
 
-import { Fragment } from "react";
-import type { Glossary as GlossaryData } from "../api";
-import { emphasized } from "../markup";
+import { Fragment } from 'react';
+import type { Glossary as GlossaryData } from '../api';
+import { emphasized } from '../markup';
 
 export function Glossary({ glossary }: { glossary: GlossaryData }) {
-  if (glossary.layout === "notes") {
+  if (glossary.layout === 'notes') {
     // Interpretation notes (e.g. the HIPs tab's HIP-1 reading rules): bolded
     // lead-ins with prose, not the term/definition grid.
     return (

--- a/web/src/components/MetricTiles.tsx
+++ b/web/src/components/MetricTiles.tsx
@@ -7,9 +7,9 @@
  * the steps that produced it.
  */
 
-import { useState } from "react";
-import type { MetricTile } from "../api";
-import { ChartLightbox, type LightboxContent } from "./ChartLightbox";
+import { useState } from 'react';
+import type { MetricTile } from '../api';
+import { ChartLightbox, type LightboxContent } from './ChartLightbox';
 
 export function MetricTiles({ tiles }: { tiles: MetricTile[] }) {
   const [explained, setExplained] = useState<LightboxContent | null>(null);
@@ -24,13 +24,17 @@ export function MetricTiles({ tiles }: { tiles: MetricTile[] }) {
           const explainable = Boolean(tile.note || tile.methodology?.length);
           const body = (
             <>
-              <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-soft">{tile.label}</div>
-              <div className="mt-1 text-[26px] font-semibold text-ink tabular-nums">{tile.value}</div>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.05em] text-soft">
+                {tile.label}
+              </div>
+              <div className="mt-1 text-[26px] font-semibold text-ink tabular-nums">
+                {tile.value}
+              </div>
             </>
           );
           const shell =
-            "rounded-[10px] border border-solid border-edge bg-surface px-4 py-3.5 text-left " +
-            "transition-[border-color,transform,box-shadow] duration-[120ms] motion-reduce:transition-none";
+            'rounded-[10px] border border-solid border-edge bg-surface px-4 py-3.5 text-left ' +
+            'transition-[border-color,transform,box-shadow] duration-[120ms] motion-reduce:transition-none';
           return explainable ? (
             <button
               key={tile.label}
@@ -38,7 +42,12 @@ export function MetricTiles({ tiles }: { tiles: MetricTile[] }) {
               className={`${shell} cursor-pointer hover:border-soft hover:-translate-y-px hover:shadow-sm motion-reduce:hover:translate-y-0`}
               title="How is this measured?"
               onClick={() =>
-                setExplained({ alt: tile.label, title: tile.label, note: tile.note, methodology: tile.methodology })
+                setExplained({
+                  alt: tile.label,
+                  title: tile.label,
+                  note: tile.note,
+                  methodology: tile.methodology,
+                })
               }
             >
               {body}

--- a/web/src/components/PeriodTabs.tsx
+++ b/web/src/components/PeriodTabs.tsx
@@ -1,7 +1,7 @@
 /** Rolling-period selector for tables and future charts. */
 
 const TAB =
-  "cursor-pointer whitespace-nowrap rounded-md border-0 px-3 py-1.5 text-[13px] [font:inherit]";
+  'cursor-pointer whitespace-nowrap rounded-md border-0 px-3 py-1.5 text-[13px] [font:inherit]';
 const IDLE = `${TAB} bg-transparent text-muted hover:bg-raise hover:text-ink`;
 const ACTIVE = `${TAB} bg-accent font-semibold text-on-accent shadow-sm`;
 

--- a/web/src/components/ProvenanceFooter.tsx
+++ b/web/src/components/ProvenanceFooter.tsx
@@ -1,14 +1,14 @@
 /** The page-level provenance line: data watermark and code revision. */
 
-import type { Manifest } from "../api";
-import { stamp } from "../format";
+import type { Manifest } from '../api';
+import { stamp } from '../format';
 
-export function ProvenanceFooter({ provenance }: { provenance: Manifest["provenance"] }) {
+export function ProvenanceFooter({ provenance }: { provenance: Manifest['provenance'] }) {
   const line = [
     provenance.data_as_of && `data ${stamp(provenance.data_as_of)} UTC`,
     provenance.git_sha && `code ${provenance.git_sha}`,
   ]
     .filter(Boolean)
-    .join(" · ");
+    .join(' · ');
   return <footer className="provenance">{line}</footer>;
 }

--- a/web/src/components/SectionCard.tsx
+++ b/web/src/components/SectionCard.tsx
@@ -7,8 +7,8 @@
  * (or the "data as of" treatment) cannot apply to one and miss the other.
  */
 
-import type { ReactNode } from "react";
-import { stamp } from "../format";
+import type { ReactNode } from 'react';
+import { stamp } from '../format';
 
 export function SectionCard({
   id,
@@ -43,9 +43,9 @@ export function SectionCard({
           <div className="sactions">
             {actions && <div className="actionrow">{actions}</div>}
             {generatedAt && (
-              <span className={stale ? "asof stale" : "asof"}>
+              <span className={stale ? 'asof stale' : 'asof'}>
                 data as of {stamp(generatedAt)}
-                {stale ? " — older than the scheduled refresh" : ""}
+                {stale ? ' — older than the scheduled refresh' : ''}
               </span>
             )}
           </div>

--- a/web/src/components/SectionGroups.tsx
+++ b/web/src/components/SectionGroups.tsx
@@ -3,14 +3,14 @@
  * With a single group, sections render bare — the header would be redundant.
  */
 
-import type { ReactNode } from "react";
+import type { ReactNode } from 'react';
 
 export type Group = [name: string, content: ReactNode];
 
 // Position-qualified so two groups can never collide on a key or an anchor —
 // distinct names can slug to the same string ("Roles & teams" / "Roles teams"),
 // and a name could in principle repeat.
-const anchorId = (name: string, index: number) => `grp-${index}-${name.replace(/\W+/g, "-")}`;
+const anchorId = (name: string, index: number) => `grp-${index}-${name.replace(/\W+/g, '-')}`;
 
 export function SectionGroups({ groups }: { groups: Group[] }) {
   const showHeaders = groups.length > 1;

--- a/web/src/components/SectionTable.tsx
+++ b/web/src/components/SectionTable.tsx
@@ -4,15 +4,15 @@
  * table core.
  */
 
-import { useState } from "react";
-import type { Manifest, SectionDoc } from "../api";
-import { safeUrl } from "../safety";
-import { useDataTable } from "../useDataTable";
-import { CopyLinkButton } from "./CopyLinkButton";
-import { CsvDownloadButton } from "./CsvDownloadButton";
-import { DataTable } from "./DataTable";
-import { PeriodTabs } from "./PeriodTabs";
-import { SectionCard } from "./SectionCard";
+import { useState } from 'react';
+import type { Manifest, SectionDoc } from '../api';
+import { safeUrl } from '../safety';
+import { useDataTable } from '../useDataTable';
+import { CopyLinkButton } from './CopyLinkButton';
+import { CsvDownloadButton } from './CsvDownloadButton';
+import { DataTable } from './DataTable';
+import { PeriodTabs } from './PeriodTabs';
+import { SectionCard } from './SectionCard';
 
 export function SectionTable({
   doc,
@@ -20,7 +20,7 @@ export function SectionTable({
   periodLabels,
 }: {
   doc: SectionDoc;
-  provenance: Manifest["provenance"];
+  provenance: Manifest['provenance'];
   periodLabels?: Record<string, string>;
 }) {
   const [period, setPeriod] = useState<string | null>(null);

--- a/web/src/components/StatusBoard.tsx
+++ b/web/src/components/StatusBoard.tsx
@@ -4,8 +4,8 @@
  * bar's button jumps to the entity's row in the target view (the matrix).
  */
 
-import { useState } from "react";
-import type { BoardItem, BoardView } from "../api";
+import { useState } from 'react';
+import type { BoardItem, BoardView } from '../api';
 
 export function StatusBoard({ view, onJump }: { view: BoardView; onJump: (hip: number) => void }) {
   const [picked, setPicked] = useState<BoardItem | null>(null);
@@ -24,7 +24,7 @@ export function StatusBoard({ view, onJump }: { view: BoardView; onJump: (hip: n
                 <button
                   key={item.key}
                   type="button"
-                  className={picked?.key === item.key ? "hipchip active" : "hipchip"}
+                  className={picked?.key === item.key ? 'hipchip active' : 'hipchip'}
                   title={`${item.title} · ${item.status}`}
                   onClick={() => setPicked((current) => (current?.key === item.key ? null : item))}
                 >

--- a/web/src/components/TabBar.tsx
+++ b/web/src/components/TabBar.tsx
@@ -13,10 +13,10 @@ export function TabBar({
   items: string[];
   active: string;
   onSelect: (item: string) => void;
-  kind: "macro" | "tab";
+  kind: 'macro' | 'tab';
 }) {
   return (
-    <nav className={kind === "macro" ? "macrobar" : "tabbar"}>
+    <nav className={kind === 'macro' ? 'macrobar' : 'tabbar'}>
       {items.map((name) => (
         <button
           key={name}

--- a/web/src/components/ViewCards.tsx
+++ b/web/src/components/ViewCards.tsx
@@ -5,15 +5,15 @@
  * section — same rows the evidence table shows, no duplicated payload.
  */
 
-import { useMemo, useRef, useState } from "react";
-import type { BoardView, Manifest, MatrixView, Row, SectionDoc, ViewDoc } from "../api";
-import { CoverageMatrix, type JumpRequest } from "./CoverageMatrix";
-import { type CsvExportSource } from "../csv";
-import { CopyLinkButton } from "./CopyLinkButton";
-import { CsvDownloadButton } from "./CsvDownloadButton";
-import type { EvidenceItem } from "./EvidencePanel";
-import { SectionCard } from "./SectionCard";
-import { StatusBoard } from "./StatusBoard";
+import { useMemo, useRef, useState } from 'react';
+import type { BoardView, Manifest, MatrixView, Row, SectionDoc, ViewDoc } from '../api';
+import { CoverageMatrix, type JumpRequest } from './CoverageMatrix';
+import { type CsvExportSource } from '../csv';
+import { CopyLinkButton } from './CopyLinkButton';
+import { CsvDownloadButton } from './CsvDownloadButton';
+import type { EvidenceItem } from './EvidencePanel';
+import { SectionCard } from './SectionCard';
+import { StatusBoard } from './StatusBoard';
 
 /** Per-cell evidence keyed "<entity>|<repo>", newest merged first. */
 function evidenceByCell(rows: Row[]): Map<string, EvidenceItem[]> {
@@ -23,12 +23,12 @@ function evidenceByCell(rows: Row[]): Map<string, EvidenceItem[]> {
     const items = cells.get(key) ?? [];
     items.push({
       n: Number(row.pr_number),
-      t: String(row.pr_title ?? "").slice(0, 100),
-      st: String(row.pr_state ?? ""),
-      d: row.pr_merged_at ? String(row.pr_merged_at).slice(0, 10) : "",
-      m: String(row.match_sources ?? ""),
-      q: row.qualifier ? String(row.qualifier) : "",
-      x: row.snippet ? String(row.snippet).slice(0, 90) : "",
+      t: String(row.pr_title ?? '').slice(0, 100),
+      st: String(row.pr_state ?? ''),
+      d: row.pr_merged_at ? String(row.pr_merged_at).slice(0, 10) : '',
+      m: String(row.match_sources ?? ''),
+      q: row.qualifier ? String(row.qualifier) : '',
+      x: row.snippet ? String(row.snippet).slice(0, 90) : '',
     });
     cells.set(key, items);
   }
@@ -40,28 +40,33 @@ function evidenceByCell(rows: Row[]): Map<string, EvidenceItem[]> {
 
 /** The matrix as the reader sees it — wide format, one column per component. */
 function matrixExport(view: MatrixView): CsvExportSource {
-  const sdkColumns = view.columns.filter((column) => column.band === "SDKs");
+  const sdkColumns = view.columns.filter((column) => column.band === 'SDKs');
   return {
-    name: "hip_coverage_matrix",
+    name: 'hip_coverage_matrix',
     title: view.title,
     columns: [
-      { key: "hip", label: "hip" },
-      { key: "title", label: "title" },
-      { key: "status", label: "status" },
+      { key: 'hip', label: 'hip' },
+      { key: 'title', label: 'title' },
+      { key: 'status', label: 'status' },
       ...view.columns.map((column) => ({ key: column.key, label: column.label })),
-      { key: "gaps", label: "no_merged_sdk_prs_in" },
+      { key: 'gaps', label: 'no_merged_sdk_prs_in' },
     ],
     rows: view.rows.map((row) => {
       const byKey = new Map(row.cells.map((cell) => [cell.key, cell]));
       const record: Row = { hip: row.key, title: row.sublabel, status: row.status };
       for (const column of view.columns) {
         const cell = byKey.get(column.key);
-        record[column.key] = !cell || cell.merged === 0 ? (cell && cell.open > 0 ? `open:${cell.open}` : 0) : cell.merged;
+        record[column.key] =
+          !cell || cell.merged === 0
+            ? cell && cell.open > 0
+              ? `open:${cell.open}`
+              : 0
+            : cell.merged;
       }
       record.gaps = sdkColumns
         .filter((column) => (byKey.get(column.key)?.merged ?? 0) === 0)
         .map((column) => column.label)
-        .join(" | ");
+        .join(' | ');
       return record;
     }),
   };
@@ -69,13 +74,13 @@ function matrixExport(view: MatrixView): CsvExportSource {
 
 function boardExport(view: BoardView): CsvExportSource {
   return {
-    name: "hip_governance_board",
+    name: 'hip_governance_board',
     title: view.title,
     columns: [
-      { key: "hip", label: "hip" },
-      { key: "title", label: "title" },
-      { key: "status", label: "status" },
-      { key: "board_column", label: "board_column" },
+      { key: 'hip', label: 'hip' },
+      { key: 'title', label: 'title' },
+      { key: 'status', label: 'status' },
+      { key: 'board_column', label: 'board_column' },
     ],
     rows: view.columns.flatMap((column) =>
       column.items.map((item) => ({
@@ -95,12 +100,12 @@ export function ViewCards({
 }: {
   views: ViewDoc[];
   sectionDocs: SectionDoc[];
-  provenance: Manifest["provenance"];
+  provenance: Manifest['provenance'];
 }) {
   const [jump, setJump] = useState<JumpRequest | null>(null);
   const jumpCounter = useRef(0);
 
-  const matrix = views.find((view): view is MatrixView => view.kind === "matrix");
+  const matrix = views.find((view): view is MatrixView => view.kind === 'matrix');
   const evidence = useMemo(() => {
     const evidenceDoc = matrix && sectionDocs.find((doc) => doc.id === matrix.evidence_section);
     return evidenceByCell(evidenceDoc?.rows ?? []);
@@ -109,7 +114,7 @@ export function ViewCards({
   return (
     <>
       {views.map((view) => {
-        const exportSource = view.kind === "board" ? boardExport(view) : matrixExport(view);
+        const exportSource = view.kind === 'board' ? boardExport(view) : matrixExport(view);
         return (
           <SectionCard
             key={view.id}
@@ -133,7 +138,7 @@ export function ViewCards({
               </>
             }
           >
-            {view.kind === "board" ? (
+            {view.kind === 'board' ? (
               // The board names the view its chips jump to, so a future board
               // could target something other than the coverage matrix.
               <StatusBoard

--- a/web/src/components/WipFooter.tsx
+++ b/web/src/components/WipFooter.tsx
@@ -1,6 +1,6 @@
 /** The work-in-progress disclaimer footer, and the page's report-a-problem link. */
 
-import { safeUrl } from "../safety";
+import { safeUrl } from '../safety';
 
 export function WipFooter({ issuesUrl }: { issuesUrl?: string }) {
   // Only the affiliations table carries a contextual "Suggest a correction"
@@ -12,12 +12,12 @@ export function WipFooter({ issuesUrl }: { issuesUrl?: string }) {
     <footer className="mb-2 max-w-[62ch] text-[13px] leading-normal text-muted">
       <span className="mr-1.5 inline-block rounded bg-warn/20 px-2 py-[2px] text-[11px] font-semibold tracking-[0.04em] uppercase text-warn-ink">
         Work in progress
-      </span>{" "}
-      This dashboard is under active development. Organisation affiliations are curated and still being
-      verified — figures are directional and may change.{" "}
+      </span>{' '}
+      This dashboard is under active development. Organisation affiliations are curated and still
+      being verified — figures are directional and may change.{' '}
       {href ? (
         <>
-          Spotted something wrong?{" "}
+          Spotted something wrong?{' '}
           <a href={href} target="_blank" rel="noopener noreferrer" className="cell-link">
             Open an issue
           </a>

--- a/web/src/csv.ts
+++ b/web/src/csv.ts
@@ -4,12 +4,12 @@
  * and "N of M" when the view is filtered).
  */
 
-import type { ColumnSpec, Manifest, Row } from "./api";
-import { stamp } from "./format";
-import { csvSafe } from "./safety";
+import type { ColumnSpec, Manifest, Row } from './api';
+import { stamp } from './format';
+import { csvSafe } from './safety';
 
 /** An export before the row-count context is attached (views build these). */
-export type CsvExportSource = Omit<CsvExport, "total" | "dataAsOf">;
+export type CsvExportSource = Omit<CsvExport, 'total' | 'dataAsOf'>;
 
 export interface CsvExport {
   name: string;
@@ -28,8 +28,8 @@ const quote = (value: unknown) => {
 
 /** Trigger a browser download of prepared CSV text. */
 function saveCsv(filename: string, text: string) {
-  const blob = new Blob([text], { type: "text/csv" });
-  const anchor = document.createElement("a");
+  const blob = new Blob([text], { type: 'text/csv' });
+  const anchor = document.createElement('a');
   anchor.href = URL.createObjectURL(blob);
   anchor.download = filename;
   anchor.click();
@@ -37,13 +37,17 @@ function saveCsv(filename: string, text: string) {
 }
 
 /** The `# …` provenance preamble both download paths share. */
-function preamble(title: string, dataAsOf: string | undefined, provenance: Manifest["provenance"]): string[] {
+function preamble(
+  title: string,
+  dataAsOf: string | undefined,
+  provenance: Manifest['provenance'],
+): string[] {
   const watermark = [
     dataAsOf && `data as of ${stamp(dataAsOf)}`,
     provenance.git_sha && `code ${provenance.git_sha}`,
   ]
     .filter(Boolean)
-    .join(" · ");
+    .join(' · ');
   return [`# Hiero analytics — ${title}`, ...(watermark ? [`# ${watermark}`] : [])];
 }
 
@@ -55,20 +59,20 @@ export function downloadCsvText(
   name: string,
   title: string,
   text: string,
-  provenance: Manifest["provenance"],
+  provenance: Manifest['provenance'],
   dataAsOf?: string,
 ) {
-  saveCsv(name, [...preamble(title, dataAsOf, provenance), text.trimEnd()].join("\n") + "\n");
+  saveCsv(name, [...preamble(title, dataAsOf, provenance), text.trimEnd()].join('\n') + '\n');
 }
 
-export function downloadCsv(payload: CsvExport, provenance: Manifest["provenance"]) {
+export function downloadCsv(payload: CsvExport, provenance: Manifest['provenance']) {
   const lines = [
     ...preamble(payload.title, payload.dataAsOf, provenance),
     ...(payload.rows.length !== payload.total
       ? [`# ${payload.rows.length} of ${payload.total} rows (filtered view)`]
       : []),
-    payload.columns.map((column) => quote(column.label)).join(","),
-    ...payload.rows.map((row) => payload.columns.map((column) => quote(row[column.key])).join(",")),
+    payload.columns.map((column) => quote(column.label)).join(','),
+    ...payload.rows.map((row) => payload.columns.map((column) => quote(row[column.key])).join(',')),
   ];
-  saveCsv(`${payload.name}.csv`, lines.join("\n"));
+  saveCsv(`${payload.name}.csv`, lines.join('\n'));
 }

--- a/web/src/format.ts
+++ b/web/src/format.ts
@@ -13,9 +13,9 @@ export function stamp(iso: string): string {
   const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/.test(iso);
   const date = new Date(hasZone ? iso : `${iso}Z`);
   if (Number.isNaN(date.getTime())) {
-    return iso.slice(0, 16).replace("T", " "); // unparseable: show it raw
+    return iso.slice(0, 16).replace('T', ' '); // unparseable: show it raw
   }
-  return date.toISOString().slice(0, 16).replace("T", " ");
+  return date.toISOString().slice(0, 16).replace('T', ' ');
 }
 
 /**

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './app.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './app.css';
+import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
-)
+);

--- a/web/src/markup.tsx
+++ b/web/src/markup.tsx
@@ -8,13 +8,13 @@
  * component happened to need it first.
  */
 
-import { Fragment, type ReactNode } from "react";
+import { Fragment, type ReactNode } from 'react';
 
 export function emphasized(text: string): ReactNode[] {
   return text
     .split(/(\*[^*]+\*)/)
     .map((part, index) =>
-      part.startsWith("*") && part.endsWith("*") ? (
+      part.startsWith('*') && part.endsWith('*') ? (
         <em key={index}>{part.slice(1, -1)}</em>
       ) : (
         <Fragment key={index}>{part}</Fragment>

--- a/web/src/safety.ts
+++ b/web/src/safety.ts
@@ -10,7 +10,7 @@
  */
 
 /** URL schemes a data-driven link may use. */
-const SAFE_URL_SCHEMES = new Set(["http:", "https:", "mailto:"]);
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
 
 /**
  * The URL if it is safe to link to, otherwise null.
@@ -36,7 +36,7 @@ export function safeUrl(value: string): string | null {
 // side neutralises for its spreadsheet copies (export/csv_safety.py). The
 // control characters count because a leading tab, CR or LF is stripped on
 // import, exposing whatever follows it to the formula parser.
-const FORMULA_PREFIXES = ["=", "+", "-", "@", "\t", "\r", "\n"];
+const FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r', '\n'];
 
 /**
  * A cell a spreadsheet will treat as text, never as a formula.
@@ -45,6 +45,6 @@ const FORMULA_PREFIXES = ["=", "+", "-", "@", "\t", "\r", "\n"];
  * alone: it is the dashboard's empty-cell placeholder, not a formula.
  */
 export function csvSafe(value: unknown): string {
-  const text = value === null || value === undefined ? "" : String(value);
-  return text && text !== "-" && FORMULA_PREFIXES.includes(text[0]) ? `'${text}` : text;
+  const text = value === null || value === undefined ? '' : String(value);
+  return text && text !== '-' && FORMULA_PREFIXES.includes(text[0]) ? `'${text}` : text;
 }

--- a/web/src/share.ts
+++ b/web/src/share.ts
@@ -8,7 +8,7 @@
 /** This page's URL with `widget` set to the named section. */
 export function shareUrl(sectionId: string): string {
   const params = new URLSearchParams(window.location.hash.slice(1));
-  params.set("widget", sectionId);
+  params.set('widget', sectionId);
   return `${window.location.origin}${window.location.pathname}#${params.toString()}`;
 }
 
@@ -21,8 +21,6 @@ export async function copyText(text: string): Promise<boolean> {
       await navigator.clipboard.writeText(text);
       return true;
     }
-  } catch {
-
-  }
+  } catch {}
   return false;
 }

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -4,11 +4,11 @@
  * (sorting, filtering, period tabs, the action link).
  */
 
-import { render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import App from "../App";
-import { stubApi } from "./fixtures";
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../App';
+import { stubApi } from './fixtures';
 
 beforeEach(() => {
   vi.unstubAllGlobals();
@@ -17,186 +17,188 @@ beforeEach(() => {
 
 const openGovernance = async () => {
   render(<App />);
-  await screen.findByRole("button", { name: "Governance" });
-  await userEvent.click(screen.getByRole("button", { name: "Governance" }));
-  return await screen.findByText("Role holders");
+  await screen.findByRole('button', { name: 'Governance' });
+  await userEvent.click(screen.getByRole('button', { name: 'Governance' }));
+  return await screen.findByText('Role holders');
 };
 
-describe("App shell", () => {
-  it("renders a macro tab per manifest macro and switches between them", async () => {
+describe('App shell', () => {
+  it('renders a macro tab per manifest macro and switches between them', async () => {
     render(<App />);
 
-    expect(await screen.findByRole("button", { name: "Governance" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Contributors" })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Governance' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Contributors' })).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Governance" }));
-    expect(await screen.findByText("Role holders")).toBeInTheDocument();
-    expect(screen.getByText("Maintainer pipeline")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Governance' }));
+    expect(await screen.findByText('Role holders')).toBeInTheDocument();
+    expect(screen.getByText('Maintainer pipeline')).toBeInTheDocument();
   });
 
-  it("keeps the org filter global and sticky, explaining tabs the org lacks", async () => {
+  it('keeps the org filter global and sticky, explaining tabs the org lacks', async () => {
     render(<App />);
 
     // The org filter is present on every tab.
-    await userEvent.click(await screen.findByRole("button", { name: "Contributors" }));
-    expect(await screen.findByRole("button", { name: "hiero-hackers" })).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('button', { name: 'Contributors' }));
+    expect(await screen.findByRole('button', { name: 'hiero-hackers' })).toBeInTheDocument();
 
     // Select hiero-hackers, then open Governance: the selection sticks, and
     // the tab explains why this org has no governance content.
-    await userEvent.click(screen.getByRole("button", { name: "hiero-hackers" }));
-    await screen.findByText("erin");
-    await userEvent.click(screen.getByRole("button", { name: "Governance" }));
+    await userEvent.click(screen.getByRole('button', { name: 'hiero-hackers' }));
+    await screen.findByText('erin');
+    await userEvent.click(screen.getByRole('button', { name: 'Governance' }));
     expect(await screen.findByText(/need a published governance config/)).toBeInTheDocument();
-    expect(screen.queryByText("Role holders")).not.toBeInTheDocument();
+    expect(screen.queryByText('Role holders')).not.toBeInTheDocument();
 
     // Switching back to hiero-ledger restores the tab's content.
-    await userEvent.click(screen.getByRole("button", { name: "hiero-ledger" }));
-    expect(await screen.findByText("Role holders")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'hiero-ledger' }));
+    expect(await screen.findByText('Role holders')).toBeInTheDocument();
   });
 
-  it("switching org swaps the rendered rows", async () => {
+  it('switching org swaps the rendered rows', async () => {
     render(<App />);
-    await userEvent.click(await screen.findByRole("button", { name: "Contributors" }));
-    expect(await screen.findByText("alice")).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('button', { name: 'Contributors' }));
+    expect(await screen.findByText('alice')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "hiero-hackers" }));
-    expect(await screen.findByText("erin")).toBeInTheDocument();
-    expect(screen.queryByText("alice")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'hiero-hackers' }));
+    expect(await screen.findByText('erin')).toBeInTheDocument();
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
   });
 
-  it("renders metric tiles, the glossary, group headers, and both footers", async () => {
+  it('renders metric tiles, the glossary, group headers, and both footers', async () => {
     await openGovernance();
 
-    expect(screen.getByText("maintainers")).toBeInTheDocument();
-    expect(screen.getByText("103")).toBeInTheDocument();
-    expect(screen.getByText("How to read this — what each column means")).toBeInTheDocument();
+    expect(screen.getByText('maintainers')).toBeInTheDocument();
+    expect(screen.getByText('103')).toBeInTheDocument();
+    expect(screen.getByText('How to read this — what each column means')).toBeInTheDocument();
     // Each group appears twice: once in the jump bar (a button — deliberately
     // not a fragment link, which would clobber the tab/org hash state), once
     // as its header. The chart card renders under its own named group — there
     // is no generic "Charts" section any more.
-    expect(screen.getByRole("button", { name: "Pipeline charts" })).toBeInTheDocument();
-    expect(screen.getAllByText("Pipeline charts")).toHaveLength(2);
-    expect(screen.queryByText("Charts")).not.toBeInTheDocument();
-    expect(screen.getAllByText("Roles & teams")).toHaveLength(2);
+    expect(screen.getByRole('button', { name: 'Pipeline charts' })).toBeInTheDocument();
+    expect(screen.getAllByText('Pipeline charts')).toHaveLength(2);
+    expect(screen.queryByText('Charts')).not.toBeInTheDocument();
+    expect(screen.getAllByText('Roles & teams')).toHaveLength(2);
     expect(screen.getByText(/Work in progress/)).toBeInTheDocument();
     // The footer is the general "something looks wrong" route: only the
     // affiliations table carries a contextual correction link, so pointing
     // readers at "a table's link" left most tabs with no way to report.
-    expect(screen.getByRole("link", { name: "Open an issue" })).toHaveAttribute(
-      "href",
-      "https://example.test/issues",
+    expect(screen.getByRole('link', { name: 'Open an issue' })).toHaveAttribute(
+      'href',
+      'https://example.test/issues',
     );
     expect(screen.getByText(/data 2026-07-25 21:00 UTC · code abc1234/)).toBeInTheDocument();
   });
 });
 
-describe("Section tables", () => {
-  it("sorts by a clicked column header", async () => {
+describe('Section tables', () => {
+  it('sorts by a clicked column header', async () => {
     await openGovernance();
-    const table = screen.getByRole("table");
+    const table = screen.getByRole('table');
 
     // Numeric columns sort descending first (TanStack default), then toggle.
-    await userEvent.click(within(table).getByText("count"));
+    await userEvent.click(within(table).getByText('count'));
     let users = within(table)
-      .getAllByRole("row")
+      .getAllByRole('row')
       .slice(1)
-      .map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(users).toEqual(["alice", "bob", "carol"]);
+      .map((row) => within(row).getAllByRole('cell')[0].textContent);
+    expect(users).toEqual(['alice', 'bob', 'carol']);
 
     await userEvent.click(within(table).getByText(/count/));
     users = within(table)
-      .getAllByRole("row")
+      .getAllByRole('row')
       .slice(1)
-      .map((row) => within(row).getAllByRole("cell")[0].textContent);
-    expect(users).toEqual(["carol", "bob", "alice"]);
+      .map((row) => within(row).getAllByRole('cell')[0].textContent);
+    expect(users).toEqual(['carol', 'bob', 'alice']);
   });
 
-  it("filters rows and shows the shown-of-total badge", async () => {
+  it('filters rows and shows the shown-of-total badge', async () => {
     await openGovernance();
 
-    await userEvent.type(screen.getByPlaceholderText("Filter…"), "ali");
-    expect(screen.getByText("1 of 3")).toBeInTheDocument();
-    expect(screen.queryByText("bob")).not.toBeInTheDocument();
+    await userEvent.type(screen.getByPlaceholderText('Filter…'), 'ali');
+    expect(screen.getByText('1 of 3')).toBeInTheDocument();
+    expect(screen.queryByText('bob')).not.toBeInTheDocument();
   });
 
-  it("period tabs swap the row set", async () => {
+  it('period tabs swap the row set', async () => {
     await openGovernance();
-    expect(screen.getByText("bob")).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "1 month" }));
-    expect(screen.queryByText("bob")).not.toBeInTheDocument();
-    expect(screen.getByText("alice")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: '1 month' }));
+    expect(screen.queryByText('bob')).not.toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "All time" }));
-    expect(screen.getByText("bob")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'All time' }));
+    expect(screen.getByText('bob')).toBeInTheDocument();
   });
 
-  it("formats number columns with separators and tabular figures", async () => {
+  it('formats number columns with separators and tabular figures', async () => {
     await openGovernance();
 
-    const cell = screen.getByText("2,490"); // 2490 renders with a separator
+    const cell = screen.getByText('2,490'); // 2490 renders with a separator
     // Cells centre by default; `num` is what earns a column tabular digits.
-    expect(cell.closest("td")).toHaveClass("num");
-    const table = screen.getByRole("table");
-    expect(within(table).getByText("count").closest("th")).toHaveClass("num");
+    expect(cell.closest('td')).toHaveClass('num');
+    const table = screen.getByRole('table');
+    expect(within(table).getByText('count').closest('th')).toHaveClass('num');
   });
 
-  it("offers the period windows shortest-first, with all time last", async () => {
+  it('offers the period windows shortest-first, with all time last', async () => {
     await openGovernance();
 
-    const tabs = within(screen.getByRole("group", { name: "Time range" })).getAllByRole("button");
+    const tabs = within(screen.getByRole('group', { name: 'Time range' })).getAllByRole('button');
 
-    expect(tabs.map((tab) => tab.textContent)).toEqual(["1 month", "All time"]);
+    expect(tabs.map((tab) => tab.textContent)).toEqual(['1 month', 'All time']);
   });
 
-  it("renders date formats, the freshness badge, and the action link", async () => {
+  it('renders date formats, the freshness badge, and the action link', async () => {
     await openGovernance();
 
-    expect(screen.getByText("2026-07-20")).toBeInTheDocument(); // date format trims time
+    expect(screen.getByText('2026-07-20')).toBeInTheDocument(); // date format trims time
     expect(screen.getByText(/data as of 2026-07-25 10:00/)).toBeInTheDocument();
-    const action = screen.getByRole("link", { name: "Suggest a correction" });
-    expect(action).toHaveAttribute("href", "https://example.test/correct");
+    const action = screen.getByRole('link', { name: 'Suggest a correction' });
+    expect(action).toHaveAttribute('href', 'https://example.test/correct');
   });
 });
 
-describe("Charts", () => {
-  it("renders variant tabs and opens the lightbox with note and methodology", async () => {
+describe('Charts', () => {
+  it('renders variant tabs and opens the lightbox with note and methodology', async () => {
     await openGovernance();
 
-    expect(screen.getByRole("button", { name: "By year" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "By month" })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'By year' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'By month' })).toBeInTheDocument();
 
-    await userEvent.click(screen.getByAltText("Unique active contributors by role"));
-    const lightbox = await screen.findByRole("dialog");
-    expect(within(lightbox).getByText("How to read this chart.")).toBeInTheDocument();
-    expect(within(lightbox).getByText("Step-by-step methodology")).toBeInTheDocument();
-    expect(within(lightbox).getByText("Step two.")).toBeInTheDocument();
+    await userEvent.click(screen.getByAltText('Unique active contributors by role'));
+    const lightbox = await screen.findByRole('dialog');
+    expect(within(lightbox).getByText('How to read this chart.')).toBeInTheDocument();
+    expect(within(lightbox).getByText('Step-by-step methodology')).toBeInTheDocument();
+    expect(within(lightbox).getByText('Step two.')).toBeInTheDocument();
 
-    await userEvent.keyboard("{Escape}");
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 });
 
-describe("Per-tab explainers", () => {
+describe('Per-tab explainers', () => {
   it("each tab shows its own explainer and no other tab's", async () => {
     render(<App />);
-    await screen.findByRole("button", { name: "Governance" });
+    await screen.findByRole('button', { name: 'Governance' });
 
-    await userEvent.click(screen.getByRole("button", { name: "Governance" }));
-    await screen.findByText("Role holders");
-    expect(screen.getByText("How to read this — what each column means")).toBeInTheDocument();
-    expect(screen.queryByText("How to read this tab — what the numbers mean")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Governance' }));
+    await screen.findByText('Role holders');
+    expect(screen.getByText('How to read this — what each column means')).toBeInTheDocument();
+    expect(
+      screen.queryByText('How to read this tab — what the numbers mean'),
+    ).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "HIPs" }));
-    await screen.findByText("Implementation coverage matrix");
-    expect(screen.getByText("How to read this tab — what the numbers mean")).toBeInTheDocument();
-    expect(screen.queryByText("How to read this — what each column means")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'HIPs' }));
+    await screen.findByText('Implementation coverage matrix');
+    expect(screen.getByText('How to read this tab — what the numbers mean')).toBeInTheDocument();
+    expect(screen.queryByText('How to read this — what each column means')).not.toBeInTheDocument();
   });
 });
 
-describe("Cell formats", () => {
-  it("renders a presence column as a labelled chip, not a bare tick", async () => {
-    const { FormattedCell } = await import("../components/FormattedCell");
+describe('Cell formats', () => {
+  it('renders a presence column as a labelled chip, not a bare tick', async () => {
+    const { FormattedCell } = await import('../components/FormattedCell');
     const { container } = render(
       <>
         <FormattedCell value={true} format="presence" />
@@ -204,176 +206,184 @@ describe("Cell formats", () => {
       </>,
     );
 
-    expect(container.textContent).toBe("presentmissing");
-    expect(container.querySelector(".chip-merged")).toBeInTheDocument();
-    expect(container.querySelector(".chip-none")).toBeInTheDocument();
+    expect(container.textContent).toBe('presentmissing');
+    expect(container.querySelector('.chip-merged')).toBeInTheDocument();
+    expect(container.querySelector('.chip-none')).toBeInTheDocument();
   });
 });
 
-describe("KPI tiles", () => {
-  it("expands an annotated tile into its note and derivation steps", async () => {
+describe('KPI tiles', () => {
+  it('expands an annotated tile into its note and derivation steps', async () => {
     render(<App />);
-    await userEvent.click(await screen.findByRole("button", { name: "Governance" }));
-    await screen.findByText("Role holders");
+    await userEvent.click(await screen.findByRole('button', { name: 'Governance' }));
+    await screen.findByText('Role holders');
 
     // A tile with an annotation is a button; one without stays inert.
-    const tile = screen.getByRole("button", { name: /maintainers 103/ });
+    const tile = screen.getByRole('button', { name: /maintainers 103/ });
     await userEvent.click(tile);
 
-    const dialog = await screen.findByRole("dialog");
-    expect(within(dialog).getByText("People whose highest role anywhere is maintainer.")).toBeInTheDocument();
-    expect(within(dialog).getByText("Step-by-step methodology")).toBeInTheDocument();
-    expect(within(dialog).getAllByRole("listitem")).toHaveLength(3);
+    const dialog = await screen.findByRole('dialog');
+    expect(
+      within(dialog).getByText('People whose highest role anywhere is maintainer.'),
+    ).toBeInTheDocument();
+    expect(within(dialog).getByText('Step-by-step methodology')).toBeInTheDocument();
+    expect(within(dialog).getAllByRole('listitem')).toHaveLength(3);
 
-    await userEvent.keyboard("{Escape}");
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /quiet teams 2/ })).not.toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /quiet teams 2/ })).not.toBeInTheDocument();
   });
 });
 
-describe("Resilience", () => {
-  it("renders what loaded and names what did not, instead of blanking the tab", async () => {
+describe('Resilience', () => {
+  it('renders what loaded and names what did not, instead of blanking the tab', async () => {
     // The tab's only table 404s; its charts and tiles must survive it.
     vi.unstubAllGlobals();
-    const { MANIFEST } = await import("./fixtures");
+    const { MANIFEST } = await import('./fixtures');
     vi.stubGlobal(
-      "fetch",
+      'fetch',
       vi.fn(async (url: string) => {
-        if (String(url).endsWith("manifest.json")) return new Response(JSON.stringify(MANIFEST));
-        if (String(url).endsWith("roles.json")) return new Response("gone", { status: 404 });
-        return new Response("{}", { status: 200 });
+        if (String(url).endsWith('manifest.json')) return new Response(JSON.stringify(MANIFEST));
+        if (String(url).endsWith('roles.json')) return new Response('gone', { status: 404 });
+        return new Response('{}', { status: 200 });
       }),
     );
 
     render(<App />);
-    await userEvent.click(await screen.findByRole("button", { name: "Governance" }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Governance' }));
 
     // The failure is named rather than silent or fatal…
     expect(await screen.findByText(/Could not load/)).toBeInTheDocument();
     expect(screen.getByText(/Role holders/)).toBeInTheDocument();
     // …while the rest of the tab still renders.
-    expect(screen.getByText("Maintainer pipeline")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /maintainers 103/ })).toBeInTheDocument();
+    expect(screen.getByText('Maintainer pipeline')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /maintainers 103/ })).toBeInTheDocument();
   });
 });
 
-describe("Section groups", () => {
-  it("gives colliding group names distinct keys and anchors", async () => {
-    const { SectionGroups } = await import("../components/SectionGroups");
+describe('Section groups', () => {
+  it('gives colliding group names distinct keys and anchors', async () => {
+    const { SectionGroups } = await import('../components/SectionGroups');
     // Distinct names that slug identically, plus an outright repeat.
     const { container } = render(
       <SectionGroups
         groups={[
-          ["Roles & teams", <p key="a">a</p>],
-          ["Roles  teams", <p key="b">b</p>],
-          ["Roles & teams", <p key="c">c</p>],
+          ['Roles & teams', <p key="a">a</p>],
+          ['Roles  teams', <p key="b">b</p>],
+          ['Roles & teams', <p key="c">c</p>],
         ]}
       />,
     );
 
-    const ids = [...container.querySelectorAll("details.group")].map((el) => el.id);
+    const ids = [...container.querySelectorAll('details.group')].map((el) => el.id);
     expect(new Set(ids).size).toBe(3); // no duplicate DOM ids
 
     // Every jump button scrolls its own group, even under name collisions.
     const scrolled: Element[] = [];
-    const spy = vi
-      .spyOn(Element.prototype, "scrollIntoView")
-      .mockImplementation(function (this: Element) {
-        scrolled.push(this);
-      });
-    for (const button of container.querySelectorAll("button.jbtn")) {
+    const spy = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(function (
+      this: Element,
+    ) {
+      scrolled.push(this);
+    });
+    for (const button of container.querySelectorAll('button.jbtn')) {
       await userEvent.click(button);
     }
     spy.mockRestore();
     expect(scrolled.map((el) => el.id)).toEqual(ids);
   });
 
-  it("jumping to a group keeps the active tab and the hash state (#342)", async () => {
+  it('jumping to a group keeps the active tab and the hash state (#342)', async () => {
     await openGovernance();
-    expect(window.location.hash).toContain("tab=Governance");
+    expect(window.location.hash).toContain('tab=Governance');
 
-    await userEvent.click(screen.getByRole("button", { name: "Roles & teams" }));
+    await userEvent.click(screen.getByRole('button', { name: 'Roles & teams' }));
 
     // The jump must not clobber the hash the app stores its state in: the
     // Governance content is still on screen and the hash still names the tab.
-    expect(screen.getByText("Role holders")).toBeInTheDocument();
-    expect(window.location.hash).toContain("tab=Governance");
-    expect(window.location.hash).not.toContain("grp-");
+    expect(screen.getByText('Role holders')).toBeInTheDocument();
+    expect(window.location.hash).toContain('tab=Governance');
+    expect(window.location.hash).not.toContain('grp-');
   });
 });
 
-describe("Loading, empty-filter, and error states (#343)", () => {
-  it("shows the header and an initial-load placeholder before the manifest arrives", async () => {
+describe('Loading, empty-filter, and error states (#343)', () => {
+  it('shows the header and an initial-load placeholder before the manifest arrives', async () => {
     vi.unstubAllGlobals();
     let resolveManifest!: (response: Response) => void;
     const pending = new Promise<Response>((resolve) => {
       resolveManifest = resolve;
     });
-    const { MANIFEST } = await import("./fixtures");
-    stubApi({ "manifest.json": () => pending });
+    const { MANIFEST } = await import('./fixtures');
+    stubApi({ 'manifest.json': () => pending });
 
     render(<App />);
 
-    expect(screen.getByRole("heading", { name: "Hiero — analytics dashboard" })).toBeInTheDocument();
-    expect(screen.getByRole("status", { name: "Loading dashboard" })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Hiero — analytics dashboard' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Loading dashboard' })).toBeInTheDocument();
 
     resolveManifest(new Response(JSON.stringify(MANIFEST)));
-    expect(await screen.findByRole("button", { name: "Governance" })).toBeInTheDocument();
-    expect(screen.queryByRole("status", { name: "Loading dashboard" })).not.toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Governance' })).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Loading dashboard' })).not.toBeInTheDocument();
   });
 
-  it("shows a tab-switch skeleton while a section is still fetching", async () => {
+  it('shows a tab-switch skeleton while a section is still fetching', async () => {
     vi.unstubAllGlobals();
     let resolveRoles!: (response: Response) => void;
     const pendingRoles = new Promise<Response>((resolve) => {
       resolveRoles = resolve;
     });
-    const { GOV_DOC } = await import("./fixtures");
-    stubApi({ "roles.json": () => pendingRoles });
+    const { GOV_DOC } = await import('./fixtures');
+    stubApi({ 'roles.json': () => pendingRoles });
 
     render(<App />);
-    await userEvent.click(await screen.findByRole("button", { name: "Governance" }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Governance' }));
 
-    expect(screen.getByRole("status", { name: "Loading tab" })).toBeInTheDocument();
-    expect(screen.queryByText("Role holders")).not.toBeInTheDocument();
+    expect(screen.getByRole('status', { name: 'Loading tab' })).toBeInTheDocument();
+    expect(screen.queryByText('Role holders')).not.toBeInTheDocument();
 
     resolveRoles(new Response(JSON.stringify(GOV_DOC)));
-    expect(await screen.findByText("Role holders")).toBeInTheDocument();
-    expect(screen.queryByRole("status", { name: "Loading tab" })).not.toBeInTheDocument();
+    expect(await screen.findByText('Role holders')).toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Loading tab' })).not.toBeInTheDocument();
   });
 
-  it("shows a no-matches message when a filter excludes every row, and clears it", async () => {
+  it('shows a no-matches message when a filter excludes every row, and clears it', async () => {
     await openGovernance();
 
-    await userEvent.type(screen.getByPlaceholderText("Filter…"), "nobody-has-this-name");
+    await userEvent.type(screen.getByPlaceholderText('Filter…'), 'nobody-has-this-name');
     expect(await screen.findByText(/No rows match/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "clear the filter?" })).toBeInTheDocument();
-    expect(screen.queryByText("alice")).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'clear the filter?' })).toBeInTheDocument();
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "clear the filter?" }));
-    expect(await screen.findByText("alice")).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'clear the filter?' }));
+    expect(await screen.findByText('alice')).toBeInTheDocument();
     expect(screen.queryByText(/No rows match/)).not.toBeInTheDocument();
   });
 
-  it("shows a fatal error with a retry button when the manifest fails to load", async () => {
+  it('shows a fatal error with a retry button when the manifest fails to load', async () => {
     vi.unstubAllGlobals();
-    const { MANIFEST } = await import("./fixtures");
+    const { MANIFEST } = await import('./fixtures');
     let attempt = 0;
     stubApi({
-      "manifest.json": () => {
+      'manifest.json': () => {
         attempt += 1;
-        return attempt === 1 ? new Response("nope", { status: 500 }) : new Response(JSON.stringify(MANIFEST));
+        return attempt === 1
+          ? new Response('nope', { status: 500 })
+          : new Response(JSON.stringify(MANIFEST));
       },
     });
 
     render(<App />);
 
-    expect(screen.getByRole("heading", { name: "Hiero — analytics dashboard" })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Hiero — analytics dashboard' }),
+    ).toBeInTheDocument();
     expect(await screen.findByText(/Failed to load the dashboard data/)).toBeInTheDocument();
-    expect(screen.getByText("Error details")).toBeInTheDocument();
+    expect(screen.getByText('Error details')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
-    expect(await screen.findByRole("button", { name: "Governance" })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(await screen.findByRole('button', { name: 'Governance' })).toBeInTheDocument();
     expect(screen.queryByText(/Failed to load the dashboard data/)).not.toBeInTheDocument();
   });
 });

--- a/web/src/test/csv.test.ts
+++ b/web/src/test/csv.test.ts
@@ -1,59 +1,59 @@
 /** The CSV export: provenance preamble, quoting, and the filtered-view note. */
 
-import { describe, expect, it, vi } from "vitest";
-import { downloadCsv, type CsvExport } from "../csv";
+import { describe, expect, it, vi } from 'vitest';
+import { downloadCsv, type CsvExport } from '../csv';
 
 const PAYLOAD: CsvExport = {
-  name: "roles",
-  title: "Role holders",
+  name: 'roles',
+  title: 'Role holders',
   columns: [
-    { key: "user", label: "user" },
-    { key: "note", label: "note" },
+    { key: 'user', label: 'user' },
+    { key: 'note', label: 'note' },
   ],
-  rows: [{ user: "alice", note: 'says "hi", loudly' }],
+  rows: [{ user: 'alice', note: 'says "hi", loudly' }],
   total: 3,
-  dataAsOf: "2026-07-25T10:00:00+00:00",
+  dataAsOf: '2026-07-25T10:00:00+00:00',
 };
 
 function captureDownload(): () => string {
-  let content = "";
+  let content = '';
   vi.stubGlobal(
-    "URL",
+    'URL',
     Object.assign(Object.create(URL), {
       createObjectURL: (blob: Blob) => {
         void blob.text().then((text) => (content = text));
-        return "blob:test";
+        return 'blob:test';
       },
       revokeObjectURL: () => {},
     }),
   );
-  vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
   return () => content;
 }
 
-describe("downloadCsv", () => {
-  it("writes the provenance preamble, the filtered note, and quoted cells", async () => {
+describe('downloadCsv', () => {
+  it('writes the provenance preamble, the filtered note, and quoted cells', async () => {
     const read = captureDownload();
 
-    downloadCsv(PAYLOAD, { git_sha: "abc1234", data_as_of: null });
-    await vi.waitFor(() => expect(read()).not.toBe(""));
+    downloadCsv(PAYLOAD, { git_sha: 'abc1234', data_as_of: null });
+    await vi.waitFor(() => expect(read()).not.toBe(''));
 
-    const lines = read().split("\n");
-    expect(lines[0]).toBe("# Hiero analytics — Role holders");
-    expect(lines[1]).toBe("# data as of 2026-07-25 10:00 · code abc1234");
-    expect(lines[2]).toBe("# 1 of 3 rows (filtered view)");
-    expect(lines[3]).toBe("user,note");
+    const lines = read().split('\n');
+    expect(lines[0]).toBe('# Hiero analytics — Role holders');
+    expect(lines[1]).toBe('# data as of 2026-07-25 10:00 · code abc1234');
+    expect(lines[2]).toBe('# 1 of 3 rows (filtered view)');
+    expect(lines[3]).toBe('user,note');
     expect(lines[4]).toBe('alice,"says ""hi"", loudly"');
   });
 
-  it("omits the filtered note when every row is exported", async () => {
+  it('omits the filtered note when every row is exported', async () => {
     const read = captureDownload();
 
     downloadCsv({ ...PAYLOAD, total: 1 }, { git_sha: null, data_as_of: null });
-    await vi.waitFor(() => expect(read()).not.toBe(""));
+    await vi.waitFor(() => expect(read()).not.toBe(''));
 
-    const lines = read().split("\n");
-    expect(lines[1]).toBe("# data as of 2026-07-25 10:00");
-    expect(lines).not.toContain("# 1 of 3 rows (filtered view)");
+    const lines = read().split('\n');
+    expect(lines[1]).toBe('# data as of 2026-07-25 10:00');
+    expect(lines).not.toContain('# 1 of 3 rows (filtered view)');
   });
 });

--- a/web/src/test/datatable.test.tsx
+++ b/web/src/test/datatable.test.tsx
@@ -9,30 +9,31 @@
  * something.
  */
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import type { Row } from "../api";
-import { DataTable, VIRTUALIZE_ABOVE } from "../components/DataTable";
-import { useDataTable } from "../useDataTable";
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { Row } from '../api';
+import { DataTable, VIRTUALIZE_ABOVE } from '../components/DataTable';
+import { useDataTable } from '../useDataTable';
 
 function Harness({ rows }: { rows: Row[] }) {
-  const table = useDataTable([{ key: "n", label: "n" }], rows, "harness");
+  const table = useDataTable([{ key: 'n', label: 'n' }], rows, 'harness');
   return <DataTable table={table} />;
 }
 
-const makeRows = (count: number): Row[] => Array.from({ length: count }, (_, index) => ({ n: index }));
+const makeRows = (count: number): Row[] =>
+  Array.from({ length: count }, (_, index) => ({ n: index }));
 
-describe("DataTable", () => {
-  it("renders a table at the threshold whole", () => {
+describe('DataTable', () => {
+  it('renders a table at the threshold whole', () => {
     render(<Harness rows={makeRows(VIRTUALIZE_ABOVE)} />);
 
-    expect(screen.getAllByRole("row")).toHaveLength(VIRTUALIZE_ABOVE + 1); // + header
+    expect(screen.getAllByRole('row')).toHaveLength(VIRTUALIZE_ABOVE + 1); // + header
   });
 
-  it("renders every row of a small table, in order", () => {
+  it('renders every row of a small table, in order', () => {
     render(<Harness rows={makeRows(5)} />);
 
-    const cells = screen.getAllByRole("cell").map((cell) => cell.textContent);
-    expect(cells).toEqual(["0", "1", "2", "3", "4"]);
+    const cells = screen.getAllByRole('cell').map((cell) => cell.textContent);
+    expect(cells).toEqual(['0', '1', '2', '3', '4']);
   });
 });

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -5,86 +5,86 @@
  * a fetch stub keyed by URL suffix — the same contract the real API honours.
  */
 
-import { vi } from "vitest";
-import type { BoardView, Manifest, MatrixView, SectionDoc } from "../api";
+import { vi } from 'vitest';
+import type { BoardView, Manifest, MatrixView, SectionDoc } from '../api';
 
 export const GOV_DOC: SectionDoc = {
-  id: "roles",
-  title: "Role holders",
-  description: "Who holds each governance role.",
-  group: "Roles & teams",
-  macro: "Governance",
-  source: "roles.csv",
+  id: 'roles',
+  title: 'Role holders',
+  description: 'Who holds each governance role.',
+  group: 'Roles & teams',
+  macro: 'Governance',
+  source: 'roles.csv',
   columns: [
-    { key: "user", label: "user" },
-    { key: "count", label: "count", format: "number" },
-    { key: "last_seen", label: "last seen", format: "date" },
+    { key: 'user', label: 'user' },
+    { key: 'count', label: 'count', format: 'number' },
+    { key: 'last_seen', label: 'last seen', format: 'date' },
   ],
   rows: [
-    { user: "carol", count: 3, last_seen: "2026-07-01T00:00:00" },
-    { user: "alice", count: 2490, last_seen: "2026-07-20T00:00:00" },
-    { user: "bob", count: 7, last_seen: "2026-07-10T00:00:00" },
+    { user: 'carol', count: 3, last_seen: '2026-07-01T00:00:00' },
+    { user: 'alice', count: 2490, last_seen: '2026-07-20T00:00:00' },
+    { user: 'bob', count: 7, last_seen: '2026-07-10T00:00:00' },
   ],
   row_count: 3,
-  action: { url: "https://example.test/correct", label: "Suggest a correction" },
-  generated_at: "2026-07-25T10:00:00+00:00",
-  periods: { "30d": [{ user: "alice", count: 4, last_seen: "2026-07-20T00:00:00" }] },
+  action: { url: 'https://example.test/correct', label: 'Suggest a correction' },
+  generated_at: '2026-07-25T10:00:00+00:00',
+  periods: { '30d': [{ user: 'alice', count: 4, last_seen: '2026-07-20T00:00:00' }] },
 };
 
 export const CONTRIB_DOC: SectionDoc = {
-  id: "profiles",
-  title: "Contributor profiles",
-  description: "Per-contributor activity.",
-  group: "All contributors",
-  macro: "Contributors",
-  source: "profiles.csv",
-  columns: [{ key: "contributor", label: "contributor" }],
-  rows: [{ contributor: "alice" }, { contributor: "bob" }],
+  id: 'profiles',
+  title: 'Contributor profiles',
+  description: 'Per-contributor activity.',
+  group: 'All contributors',
+  macro: 'Contributors',
+  source: 'profiles.csv',
+  columns: [{ key: 'contributor', label: 'contributor' }],
+  rows: [{ contributor: 'alice' }, { contributor: 'bob' }],
   row_count: 2,
 };
 
 export const HACKERS_DOC: SectionDoc = {
   ...CONTRIB_DOC,
-  rows: [{ contributor: "erin" }],
+  rows: [{ contributor: 'erin' }],
   row_count: 1,
 };
 
 export const HIP_EVIDENCE_DOC: SectionDoc = {
-  id: "hip-evidence",
-  title: "Evidence (per PR)",
-  description: "The audit trail.",
-  group: "Evidence",
-  macro: "HIPs",
-  source: "hip_pr_evidence.csv",
+  id: 'hip-evidence',
+  title: 'Evidence (per PR)',
+  description: 'The audit trail.',
+  group: 'Evidence',
+  macro: 'HIPs',
+  source: 'hip_pr_evidence.csv',
   columns: [
-    { key: "hip", label: "HIP", format: "hip" },
-    { key: "repo", label: "repository" },
-    { key: "pr_number", label: "PR" },
+    { key: 'hip', label: 'HIP', format: 'hip' },
+    { key: 'repo', label: 'repository' },
+    { key: 'pr_number', label: 'PR' },
   ],
   rows: [
     {
       hip: 1200,
-      repo: "hiero-ledger/consensus",
+      repo: 'hiero-ledger/consensus',
       pr_number: 88,
-      pr_title: "feat: HIP-1200 throughput",
-      pr_state: "MERGED",
-      pr_merged_at: "2026-06-02T00:00:00.000",
-      match_sources: "title|branch",
+      pr_title: 'feat: HIP-1200 throughput',
+      pr_state: 'MERGED',
+      pr_merged_at: '2026-06-02T00:00:00.000',
+      match_sources: 'title|branch',
       qualifier: null,
       counted: true,
-      snippet: "…HIP-1200 throughput…",
+      snippet: '…HIP-1200 throughput…',
     },
     {
       hip: 1200,
-      repo: "hiero-ledger/consensus",
+      repo: 'hiero-ledger/consensus',
       pr_number: 91,
-      pr_title: "chore: prepare for HIP-1200",
-      pr_state: "OPEN",
+      pr_title: 'chore: prepare for HIP-1200',
+      pr_state: 'OPEN',
       pr_merged_at: null,
-      match_sources: "body",
-      qualifier: "prepares for",
+      match_sources: 'body',
+      qualifier: 'prepares for',
       counted: false,
-      snippet: "…prepare for HIP-1200…",
+      snippet: '…prepare for HIP-1200…',
     },
   ],
   row_count: 2,
@@ -96,31 +96,31 @@ export const HIP_EVIDENCE_DOC: SectionDoc = {
  * honest against `FormattedCell`'s switch as both evolve.
  */
 export const ALL_FORMATS_DOC: SectionDoc = {
-  id: "all-formats",
-  title: "All formats",
-  description: "One column per supported display format.",
-  group: "Formats",
-  macro: "Governance",
-  source: "all_formats.csv",
+  id: 'all-formats',
+  title: 'All formats',
+  description: 'One column per supported display format.',
+  group: 'Formats',
+  macro: 'Governance',
+  source: 'all_formats.csv',
   columns: [
-    { key: "hip", label: "hip", format: "hip" },
-    { key: "date", label: "date", format: "date" },
-    { key: "link", label: "link", format: "link" },
-    { key: "evidence", label: "evidence", format: "evidence" },
-    { key: "status", label: "status", format: "status" },
-    { key: "flag", label: "flag", format: "flag" },
-    { key: "presence", label: "presence", format: "presence" },
-    { key: "number", label: "number", format: "number" },
+    { key: 'hip', label: 'hip', format: 'hip' },
+    { key: 'date', label: 'date', format: 'date' },
+    { key: 'link', label: 'link', format: 'link' },
+    { key: 'evidence', label: 'evidence', format: 'evidence' },
+    { key: 'status', label: 'status', format: 'status' },
+    { key: 'flag', label: 'flag', format: 'flag' },
+    { key: 'presence', label: 'presence', format: 'presence' },
+    { key: 'number', label: 'number', format: 'number' },
   ],
   rows: [
     {
       hip: 1200,
-      date: "2026-07-20T00:00:00",
-      link: "https://example.test/pr/1",
-      evidence: "merged",
-      status: "Final",
-      flag: "true",
-      presence: "true",
+      date: '2026-07-20T00:00:00',
+      link: 'https://example.test/pr/1',
+      evidence: 'merged',
+      status: 'Final',
+      flag: 'true',
+      presence: 'true',
       number: 2490,
     },
   ],
@@ -128,141 +128,177 @@ export const ALL_FORMATS_DOC: SectionDoc = {
 };
 
 export const MATRIX_DOC: MatrixView = {
-  id: "hip-matrix",
-  kind: "matrix",
-  macro: "HIPs",
-  title: "Implementation coverage matrix",
-  description: "Merged PRs referencing each HIP, per component.",
-  badge: "3 HIPs",
-  source: "hip_repo_activity.csv",
-  row_header: "Governance",
-  note_header: "No SDK PRs found in",
+  id: 'hip-matrix',
+  kind: 'matrix',
+  macro: 'HIPs',
+  title: 'Implementation coverage matrix',
+  description: 'Merged PRs referencing each HIP, per component.',
+  badge: '3 HIPs',
+  source: 'hip_repo_activity.csv',
+  row_header: 'Governance',
+  note_header: 'No SDK PRs found in',
   bands: [
-    { label: "Services", span: 1 },
-    { label: "SDKs", span: 2 },
+    { label: 'Services', span: 1 },
+    { label: 'SDKs', span: 2 },
   ],
   columns: [
-    { key: "hiero-ledger/consensus", label: "consensus", band: "Services" },
-    { key: "hiero-ledger/sdk-java", label: "java", band: "SDKs" },
-    { key: "hiero-ledger/sdk-go", label: "go", band: "SDKs" },
+    { key: 'hiero-ledger/consensus', label: 'consensus', band: 'Services' },
+    { key: 'hiero-ledger/sdk-java', label: 'java', band: 'SDKs' },
+    { key: 'hiero-ledger/sdk-go', label: 'go', band: 'SDKs' },
   ],
   rows: [
     {
       key: 1200,
-      label: "HIP-1200",
-      sublabel: "Throughput",
-      status: "Approved",
+      label: 'HIP-1200',
+      sublabel: 'Throughput',
+      status: 'Approved',
       cells: [
-        { key: "hiero-ledger/consensus", merged: 3, open: 1 },
-        { key: "hiero-ledger/sdk-java", merged: 0, open: 2 },
-        { key: "hiero-ledger/sdk-go", merged: 0, open: 0 },
+        { key: 'hiero-ledger/consensus', merged: 3, open: 1 },
+        { key: 'hiero-ledger/sdk-java', merged: 0, open: 2 },
+        { key: 'hiero-ledger/sdk-go', merged: 0, open: 0 },
       ],
-      note: { kind: "partial", text: "java · go", items: ["java", "go"] },
+      note: { kind: 'partial', text: 'java · go', items: ['java', 'go'] },
     },
     {
       key: 1100,
-      label: "HIP-1100",
-      sublabel: "Airdrops",
-      status: "Final",
+      label: 'HIP-1100',
+      sublabel: 'Airdrops',
+      status: 'Final',
       cells: [
-        { key: "hiero-ledger/consensus", merged: 1, open: 0 },
-        { key: "hiero-ledger/sdk-java", merged: 1, open: 0 },
-        { key: "hiero-ledger/sdk-go", merged: 44, open: 0 },
+        { key: 'hiero-ledger/consensus', merged: 1, open: 0 },
+        { key: 'hiero-ledger/sdk-java', merged: 1, open: 0 },
+        { key: 'hiero-ledger/sdk-go', merged: 44, open: 0 },
       ],
-      note: { kind: "complete", text: "✓ all SDKs" },
+      note: { kind: 'complete', text: '✓ all SDKs' },
     },
     {
       key: 1000,
-      label: "HIP-1000",
-      sublabel: "Dormant",
-      status: "Deferred",
+      label: 'HIP-1000',
+      sublabel: 'Dormant',
+      status: 'Deferred',
       cells: [
-        { key: "hiero-ledger/consensus", merged: 0, open: 0 },
-        { key: "hiero-ledger/sdk-java", merged: 0, open: 0 },
-        { key: "hiero-ledger/sdk-go", merged: 0, open: 0 },
+        { key: 'hiero-ledger/consensus', merged: 0, open: 0 },
+        { key: 'hiero-ledger/sdk-java', merged: 0, open: 0 },
+        { key: 'hiero-ledger/sdk-go', merged: 0, open: 0 },
       ],
-      note: { kind: "none", text: "no activity found" },
+      note: { kind: 'none', text: 'no activity found' },
     },
   ],
-  ramp: ["#cde2fb", "#9ec5f4", "#5598e7", "#2a78d6", "#104281"],
+  ramp: ['#cde2fb', '#9ec5f4', '#5598e7', '#2a78d6', '#104281'],
   ramp_ceilings: [2, 5, 15, 40],
-  filters: ["Final", "Approved", "Deferred"],
-  evidence_section: "hip-evidence",
-  generated_at: "2026-07-25T09:00:00+00:00",
+  filters: ['Final', 'Approved', 'Deferred'],
+  evidence_section: 'hip-evidence',
+  generated_at: '2026-07-25T09:00:00+00:00',
 };
 
 export const BOARD_DOC: BoardView = {
-  id: "hip-board",
-  kind: "board",
-  macro: "HIPs",
-  title: "Where specs sit in governance",
-  description: "Every HIP spec, placed by its lifecycle status.",
-  badge: "3 specs",
-  source: "hip_summary.csv",
+  id: 'hip-board',
+  kind: 'board',
+  macro: 'HIPs',
+  title: 'Where specs sit in governance',
+  description: 'Every HIP spec, placed by its lifecycle status.',
+  badge: '3 specs',
+  source: 'hip_summary.csv',
   columns: [
-    { title: "Approved (incl. legacy Accepted)", items: [{ key: 1200, label: "HIP-1200", title: "Throughput", status: "Approved" }] },
-    { title: "Final", items: [{ key: 1100, label: "HIP-1100", title: "Airdrops", status: "Final" }] },
-    { title: "Active", items: [] },
-    { title: "Retired", items: [{ key: 1000, label: "HIP-1000", title: "Dormant", status: "Deferred" }] },
+    {
+      title: 'Approved (incl. legacy Accepted)',
+      items: [{ key: 1200, label: 'HIP-1200', title: 'Throughput', status: 'Approved' }],
+    },
+    {
+      title: 'Final',
+      items: [{ key: 1100, label: 'HIP-1100', title: 'Airdrops', status: 'Final' }],
+    },
+    { title: 'Active', items: [] },
+    {
+      title: 'Retired',
+      items: [{ key: 1000, label: 'HIP-1000', title: 'Dormant', status: 'Deferred' }],
+    },
   ],
-  target_view: "hip-matrix",
+  target_view: 'hip-matrix',
 };
 
 export const MANIFEST: Manifest = {
-  version: "v1",
-  generated_at: "2026-07-25T22:00:00+00:00",
+  version: 'v1',
+  generated_at: '2026-07-25T22:00:00+00:00',
   macro_glossaries: {
     Governance: {
-      title: "How to read this — what each column means",
-      layout: "definitions",
-      terms: [{ term: "PRs", definition: "pull requests opened; *general* = no special role." }],
-      note: "Comments and reactions are not counted.",
+      title: 'How to read this — what each column means',
+      layout: 'definitions',
+      terms: [{ term: 'PRs', definition: 'pull requests opened; *general* = no special role.' }],
+      note: 'Comments and reactions are not counted.',
     },
     HIPs: {
-      title: "How to read this tab — what the numbers mean",
-      layout: "notes",
-      terms: [{ term: "What is measured.", definition: "Referencing PRs — *evidence*, never proof." }],
+      title: 'How to read this tab — what the numbers mean',
+      layout: 'notes',
+      terms: [
+        { term: 'What is measured.', definition: 'Referencing PRs — *evidence*, never proof.' },
+      ],
     },
   },
-  period_labels: { "30d": "1 month" },
-  issues_url: "https://example.test/issues",
+  period_labels: { '30d': '1 month' },
+  issues_url: 'https://example.test/issues',
   macro_absent_notes: {
-    Governance: "Governance analytics need a published governance config; this org doesn't have one.",
+    Governance:
+      "Governance analytics need a published governance config; this org doesn't have one.",
   },
-  provenance: { git_sha: "abc1234", data_as_of: "2026-07-25T21:00:00+00:00" },
+  provenance: { git_sha: 'abc1234', data_as_of: '2026-07-25T21:00:00+00:00' },
   orgs: {
-    "hiero-ledger": {
+    'hiero-ledger': {
       views: [
-        { id: "hip-board", macro: "HIPs", kind: "board", title: "Where specs sit in governance", path: "hiero-ledger/hip-board.json" },
-        { id: "hip-matrix", macro: "HIPs", kind: "matrix", title: "Implementation coverage matrix", path: "hiero-ledger/hip-matrix.json" },
+        {
+          id: 'hip-board',
+          macro: 'HIPs',
+          kind: 'board',
+          title: 'Where specs sit in governance',
+          path: 'hiero-ledger/hip-board.json',
+        },
+        {
+          id: 'hip-matrix',
+          macro: 'HIPs',
+          kind: 'matrix',
+          title: 'Implementation coverage matrix',
+          path: 'hiero-ledger/hip-matrix.json',
+        },
       ],
       sections: [
-        { id: "roles", macro: "Governance", title: "Role holders", row_count: 3, path: "hiero-ledger/roles.json" },
-        { id: "hip-evidence", macro: "HIPs", title: "Evidence (per PR)", row_count: 2, path: "hiero-ledger/hip-evidence.json" },
         {
-          id: "profiles",
-          macro: "Contributors",
-          title: "Contributor profiles",
+          id: 'roles',
+          macro: 'Governance',
+          title: 'Role holders',
+          row_count: 3,
+          path: 'hiero-ledger/roles.json',
+        },
+        {
+          id: 'hip-evidence',
+          macro: 'HIPs',
+          title: 'Evidence (per PR)',
           row_count: 2,
-          path: "hiero-ledger/profiles.json",
+          path: 'hiero-ledger/hip-evidence.json',
+        },
+        {
+          id: 'profiles',
+          macro: 'Contributors',
+          title: 'Contributor profiles',
+          row_count: 2,
+          path: 'hiero-ledger/profiles.json',
         },
       ],
       chart_sections: [
         {
-          id: "pipeline",
-          macro: "Governance",
-          title: "Maintainer pipeline",
-          group: "Pipeline charts",
-          description: "How the pipeline moved.",
+          id: 'pipeline',
+          macro: 'Governance',
+          title: 'Maintainer pipeline',
+          group: 'Pipeline charts',
+          description: 'How the pipeline moved.',
           charts: [
             {
-              title: "Unique active contributors by role",
+              title: 'Unique active contributors by role',
               variants: [
-                { label: "By year", file: "charts/org/hiero-ledger/pipeline_yearly.png" },
-                { label: "By month", file: "charts/org/hiero-ledger/pipeline_monthly.png" },
+                { label: 'By year', file: 'charts/org/hiero-ledger/pipeline_yearly.png' },
+                { label: 'By month', file: 'charts/org/hiero-ledger/pipeline_monthly.png' },
               ],
-              note: "How to read this chart.",
-              methodology: ["Step one.", "Step two."],
+              note: 'How to read this chart.',
+              methodology: ['Step one.', 'Step two.'],
             },
           ],
         },
@@ -270,23 +306,27 @@ export const MANIFEST: Manifest = {
       metrics: {
         Governance: [
           {
-            label: "maintainers",
+            label: 'maintainers',
             value: 103,
-            note: "People whose highest role anywhere is maintainer.",
-            methodology: ["Resolve roles per repository.", "Reduce to the most senior role.", "Count them."],
+            note: 'People whose highest role anywhere is maintainer.',
+            methodology: [
+              'Resolve roles per repository.',
+              'Reduce to the most senior role.',
+              'Count them.',
+            ],
           },
-          { label: "quiet teams", value: 2 },
+          { label: 'quiet teams', value: 2 },
         ],
       },
     },
-    "hiero-hackers": {
+    'hiero-hackers': {
       sections: [
         {
-          id: "profiles",
-          macro: "Contributors",
-          title: "Contributor profiles",
+          id: 'profiles',
+          macro: 'Contributors',
+          title: 'Contributor profiles',
           row_count: 1,
-          path: "hiero-hackers/profiles.json",
+          path: 'hiero-hackers/profiles.json',
         },
       ],
       chart_sections: [],
@@ -296,13 +336,13 @@ export const MANIFEST: Manifest = {
 };
 
 const ROUTES: Record<string, unknown> = {
-  "manifest.json": MANIFEST,
-  "hiero-ledger/roles.json": GOV_DOC,
-  "hiero-ledger/hip-evidence.json": HIP_EVIDENCE_DOC,
-  "hiero-ledger/hip-board.json": BOARD_DOC,
-  "hiero-ledger/hip-matrix.json": MATRIX_DOC,
-  "hiero-ledger/profiles.json": CONTRIB_DOC,
-  "hiero-hackers/profiles.json": HACKERS_DOC,
+  'manifest.json': MANIFEST,
+  'hiero-ledger/roles.json': GOV_DOC,
+  'hiero-ledger/hip-evidence.json': HIP_EVIDENCE_DOC,
+  'hiero-ledger/hip-board.json': BOARD_DOC,
+  'hiero-ledger/hip-matrix.json': MATRIX_DOC,
+  'hiero-ledger/profiles.json': CONTRIB_DOC,
+  'hiero-hackers/profiles.json': HACKERS_DOC,
 };
 
 /**
@@ -314,14 +354,14 @@ const ROUTES: Record<string, unknown> = {
  */
 export function stubApi(overrides: Record<string, () => Response | Promise<Response>> = {}) {
   return vi.stubGlobal(
-    "fetch",
+    'fetch',
     vi.fn(async (url: string) => {
       const key = String(url);
       const override = Object.entries(overrides).find(([suffix]) => key.endsWith(suffix));
       if (override) return override[1]();
       const match = Object.entries(ROUTES).find(([suffix]) => key.endsWith(suffix));
       if (!match) {
-        return new Response("not found", { status: 404 });
+        return new Response('not found', { status: 404 });
       }
       return new Response(JSON.stringify(match[1]), { status: 200 });
     }),

--- a/web/src/test/format.test.ts
+++ b/web/src/test/format.test.ts
@@ -1,44 +1,44 @@
 /** Timestamps are labelled UTC wherever they appear, so they must be in UTC. */
 
-import { describe, expect, it } from "vitest";
-import { dateStamp, stamp } from "../format";
+import { describe, expect, it } from 'vitest';
+import { dateStamp, stamp } from '../format';
 
-describe("stamp", () => {
-  it("keeps a UTC timestamp as-is", () => {
-    expect(stamp("2026-07-25T10:00:00+00:00")).toBe("2026-07-25 10:00");
-    expect(stamp("2026-07-25T10:00:00Z")).toBe("2026-07-25 10:00");
+describe('stamp', () => {
+  it('keeps a UTC timestamp as-is', () => {
+    expect(stamp('2026-07-25T10:00:00+00:00')).toBe('2026-07-25 10:00');
+    expect(stamp('2026-07-25T10:00:00Z')).toBe('2026-07-25 10:00');
   });
 
-  it("converts an offset-bearing timestamp to UTC instead of truncating it", () => {
+  it('converts an offset-bearing timestamp to UTC instead of truncating it', () => {
     // Truncating would read "10:00" and label it UTC — four hours wrong.
-    expect(stamp("2026-07-25T10:00:00-04:00")).toBe("2026-07-25 14:00");
-    expect(stamp("2026-07-25T23:30:00+05:30")).toBe("2026-07-25 18:00");
+    expect(stamp('2026-07-25T10:00:00-04:00')).toBe('2026-07-25 14:00');
+    expect(stamp('2026-07-25T23:30:00+05:30')).toBe('2026-07-25 18:00');
   });
 
   it("assumes UTC for a naive timestamp rather than the viewer's local zone", () => {
-    expect(stamp("2026-07-25T10:00:00")).toBe("2026-07-25 10:00");
-    expect(stamp("2026-07-26T13:55:36.470051")).toBe("2026-07-26 13:55");
+    expect(stamp('2026-07-25T10:00:00')).toBe('2026-07-25 10:00');
+    expect(stamp('2026-07-26T13:55:36.470051')).toBe('2026-07-26 13:55');
   });
 
-  it("shows an unparseable value raw rather than throwing", () => {
-    expect(stamp("not-a-date")).toBe("not-a-date");
+  it('shows an unparseable value raw rather than throwing', () => {
+    expect(stamp('not-a-date')).toBe('not-a-date');
   });
 });
 
-describe("dateStamp", () => {
-  it("returns just the UTC date", () => {
-    expect(dateStamp("2026-07-25T10:00:00+00:00")).toBe("2026-07-25");
-    expect(dateStamp("2026-07-25 23:20:25+00:00")).toBe("2026-07-25");
+describe('dateStamp', () => {
+  it('returns just the UTC date', () => {
+    expect(dateStamp('2026-07-25T10:00:00+00:00')).toBe('2026-07-25');
+    expect(dateStamp('2026-07-25 23:20:25+00:00')).toBe('2026-07-25');
   });
 
-  it("converts across the day boundary instead of truncating", () => {
+  it('converts across the day boundary instead of truncating', () => {
     // Truncating would report the 26th for an instant on the 25th UTC.
-    expect(dateStamp("2026-07-26T01:20:25+03:00")).toBe("2026-07-25");
-    expect(dateStamp("2026-07-25T22:30:00-04:00")).toBe("2026-07-26");
+    expect(dateStamp('2026-07-26T01:20:25+03:00')).toBe('2026-07-25');
+    expect(dateStamp('2026-07-25T22:30:00-04:00')).toBe('2026-07-26');
   });
 
-  it("assumes UTC for a naive timestamp and degrades raw when unparseable", () => {
-    expect(dateStamp("2026-07-25T10:00:00")).toBe("2026-07-25");
-    expect(dateStamp("not-a-date")).toBe("not-a-date");
+  it('assumes UTC for a naive timestamp and degrades raw when unparseable', () => {
+    expect(dateStamp('2026-07-25T10:00:00')).toBe('2026-07-25');
+    expect(dateStamp('not-a-date')).toBe('not-a-date');
   });
 });

--- a/web/src/test/formattedCell.test.tsx
+++ b/web/src/test/formattedCell.test.tsx
@@ -6,30 +6,33 @@
  * that gap would show up as a wrong rendered cell rather than shipping quiet.
  */
 
-import { render, screen, within } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { DataTable } from "../components/DataTable";
-import { useDataTable } from "../useDataTable";
-import { ALL_FORMATS_DOC } from "./fixtures";
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DataTable } from '../components/DataTable';
+import { useDataTable } from '../useDataTable';
+import { ALL_FORMATS_DOC } from './fixtures';
 
 /** Renders the fixture through the real column-format pipeline for assertions below. */
 function Harness() {
-  const table = useDataTable(ALL_FORMATS_DOC.columns, ALL_FORMATS_DOC.rows, "all-formats");
+  const table = useDataTable(ALL_FORMATS_DOC.columns, ALL_FORMATS_DOC.rows, 'all-formats');
   return <DataTable table={table} />;
 }
 
-describe("FormattedCell", () => {
-  it("renders every supported format correctly", () => {
+describe('FormattedCell', () => {
+  it('renders every supported format correctly', () => {
     render(<Harness />);
-    const row = screen.getAllByRole("row")[1]; // [0] is the header row
+    const row = screen.getAllByRole('row')[1]; // [0] is the header row
 
-    expect(within(row).getByText("HIP-1200")).toBeInTheDocument();
-    expect(within(row).getByText("2026-07-20")).toBeInTheDocument();
-    expect(within(row).getByRole("link", { name: "open ↗" })).toHaveAttribute("href", "https://example.test/pr/1");
-    expect(within(row).getByText("merged")).toBeInTheDocument();
-    expect(within(row).getByText("Final")).toBeInTheDocument();
-    expect(within(row).getByText("✓")).toBeInTheDocument();
-    expect(within(row).getByText("present")).toBeInTheDocument();
-    expect(within(row).getByText("2,490")).toBeInTheDocument();
+    expect(within(row).getByText('HIP-1200')).toBeInTheDocument();
+    expect(within(row).getByText('2026-07-20')).toBeInTheDocument();
+    expect(within(row).getByRole('link', { name: 'open ↗' })).toHaveAttribute(
+      'href',
+      'https://example.test/pr/1',
+    );
+    expect(within(row).getByText('merged')).toBeInTheDocument();
+    expect(within(row).getByText('Final')).toBeInTheDocument();
+    expect(within(row).getByText('✓')).toBeInTheDocument();
+    expect(within(row).getByText('present')).toBeInTheDocument();
+    expect(within(row).getByText('2,490')).toBeInTheDocument();
   });
 });

--- a/web/src/test/hip.test.tsx
+++ b/web/src/test/hip.test.tsx
@@ -4,11 +4,11 @@
  * tab's own explainer replacing the shared column glossary.
  */
 
-import { render, screen, within } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import App from "../App";
-import { stubApi } from "./fixtures";
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import App from '../App';
+import { stubApi } from './fixtures';
 
 beforeEach(() => {
   vi.unstubAllGlobals();
@@ -19,130 +19,139 @@ beforeEach(() => {
 
 const openHips = async () => {
   render(<App />);
-  await userEvent.click(await screen.findByRole("button", { name: "HIPs" }));
-  return await screen.findByText("Implementation coverage matrix");
+  await userEvent.click(await screen.findByRole('button', { name: 'HIPs' }));
+  return await screen.findByText('Implementation coverage matrix');
 };
 
-const matrixCard = () => screen.getByText("Implementation coverage matrix").closest(".tsec") as HTMLElement;
-const boardCard = () => screen.getByText("Where specs sit in governance").closest(".tsec") as HTMLElement;
+const matrixCard = () =>
+  screen.getByText('Implementation coverage matrix').closest('.tsec') as HTMLElement;
+const boardCard = () =>
+  screen.getByText('Where specs sit in governance').closest('.tsec') as HTMLElement;
 
-describe("HIPs tab", () => {
-  it("renders the board and matrix as cards, board first, with badges", async () => {
+describe('HIPs tab', () => {
+  it('renders the board and matrix as cards, board first, with badges', async () => {
     await openHips();
 
-    const titles = screen.getAllByRole("heading", { level: 2 }).map((heading) => heading.textContent);
-    expect(titles.indexOf("Where specs sit in governance")).toBeLessThan(
-      titles.indexOf("Implementation coverage matrix"),
+    const titles = screen
+      .getAllByRole('heading', { level: 2 })
+      .map((heading) => heading.textContent);
+    expect(titles.indexOf('Where specs sit in governance')).toBeLessThan(
+      titles.indexOf('Implementation coverage matrix'),
     );
-    expect(screen.getByText("3 specs")).toBeInTheDocument();
-    expect(screen.getByText("3 HIPs")).toBeInTheDocument();
+    expect(screen.getByText('3 specs')).toBeInTheDocument();
+    expect(screen.getByText('3 HIPs')).toBeInTheDocument();
   });
 
   it("shows the tab's own explainer instead of the shared glossary", async () => {
     await openHips();
 
-    expect(screen.getByText("How to read this tab — what the numbers mean")).toBeInTheDocument();
-    expect(screen.getByText("What is measured.")).toBeInTheDocument();
-    expect(screen.getByText("evidence")).toBeInTheDocument(); // *emphasis* rendered as <em>
+    expect(screen.getByText('How to read this tab — what the numbers mean')).toBeInTheDocument();
+    expect(screen.getByText('What is measured.')).toBeInTheDocument();
+    expect(screen.getByText('evidence')).toBeInTheDocument(); // *emphasis* rendered as <em>
     // The Governance tab's column glossary must not leak onto this tab.
-    expect(screen.queryByText("How to read this — what each column means")).not.toBeInTheDocument();
+    expect(screen.queryByText('How to read this — what each column means')).not.toBeInTheDocument();
   });
 
-  it("renders bands, heat cells, open-only markers, and every gap state", async () => {
+  it('renders bands, heat cells, open-only markers, and every gap state', async () => {
     await openHips();
     const matrix = matrixCard();
 
-    expect(within(matrix).getByText("Services")).toBeInTheDocument();
-    expect(within(matrix).getByText("SDKs")).toBeInTheDocument();
+    expect(within(matrix).getByText('Services')).toBeInTheDocument();
+    expect(within(matrix).getByText('SDKs')).toBeInTheDocument();
     // 3 merged -> m2 bucket (ceilings 2,5,15,40); 44 merged -> m5.
-    expect(within(matrix).getByText("3").className).toContain("m2");
-    expect(within(matrix).getByText("44").className).toContain("m5");
-    expect(within(matrix).getAllByText("○").length).toBeGreaterThan(0);
-    expect(within(matrix).getByText("✓ all SDKs")).toBeInTheDocument();
-    expect(within(matrix).getByText("no activity found")).toBeInTheDocument();
-    expect(within(matrix).getByText("java · go")).toBeInTheDocument();
-    expect(within(matrix).getByText("3 rows")).toBeInTheDocument();
+    expect(within(matrix).getByText('3').className).toContain('m2');
+    expect(within(matrix).getByText('44').className).toContain('m5');
+    expect(within(matrix).getAllByText('○').length).toBeGreaterThan(0);
+    expect(within(matrix).getByText('✓ all SDKs')).toBeInTheDocument();
+    expect(within(matrix).getByText('no activity found')).toBeInTheDocument();
+    expect(within(matrix).getByText('java · go')).toBeInTheDocument();
+    expect(within(matrix).getByText('3 rows')).toBeInTheDocument();
   });
 
-  it("filters by text and by governance pill, and pills toggle off", async () => {
+  it('filters by text and by governance pill, and pills toggle off', async () => {
     await openHips();
     const matrix = matrixCard();
 
-    await userEvent.type(within(matrix).getByPlaceholderText("Filter by HIP number or title…"), "airdrops");
-    expect(within(matrix).getByText("1 rows")).toBeInTheDocument();
-    await userEvent.clear(within(matrix).getByPlaceholderText("Filter by HIP number or title…"));
+    await userEvent.type(
+      within(matrix).getByPlaceholderText('Filter by HIP number or title…'),
+      'airdrops',
+    );
+    expect(within(matrix).getByText('1 rows')).toBeInTheDocument();
+    await userEvent.clear(within(matrix).getByPlaceholderText('Filter by HIP number or title…'));
 
-    await userEvent.click(within(matrix).getByRole("button", { name: "Deferred" }));
-    expect(within(matrix).getByText("1 rows")).toBeInTheDocument();
-    expect(within(matrix).queryByText("HIP-1200")).not.toBeInTheDocument();
+    await userEvent.click(within(matrix).getByRole('button', { name: 'Deferred' }));
+    expect(within(matrix).getByText('1 rows')).toBeInTheDocument();
+    expect(within(matrix).queryByText('HIP-1200')).not.toBeInTheDocument();
 
-    await userEvent.click(within(matrix).getByRole("button", { name: "Deferred" }));
-    expect(within(matrix).getByText("3 rows")).toBeInTheDocument();
+    await userEvent.click(within(matrix).getByRole('button', { name: 'Deferred' }));
+    expect(within(matrix).getByText('3 rows')).toBeInTheDocument();
   });
 
-  it("opens the evidence panel from a cell, flags uncounted references, toggles closed", async () => {
+  it('opens the evidence panel from a cell, flags uncounted references, toggles closed', async () => {
     await openHips();
     const matrix = matrixCard();
 
-    const cell = within(matrix).getByText("3");
+    const cell = within(matrix).getByText('3');
     await userEvent.click(cell);
 
-    expect(within(matrix).getByText("HIP-1200 · hiero-ledger/consensus")).toBeInTheDocument();
-    expect(within(matrix).getByText("2 referencing PRs")).toBeInTheDocument();
-    expect(within(matrix).getByText("merged 2026-06-02")).toBeInTheDocument();
-    expect(within(matrix).getByText("matched in: title, branch")).toBeInTheDocument();
-    expect(within(matrix).getByText("not counted — “prepares for”")).toBeInTheDocument();
-    const link = within(matrix).getByRole("link", { name: "#88" });
-    expect(link).toHaveAttribute("href", "https://github.com/hiero-ledger/consensus/pull/88");
+    expect(within(matrix).getByText('HIP-1200 · hiero-ledger/consensus')).toBeInTheDocument();
+    expect(within(matrix).getByText('2 referencing PRs')).toBeInTheDocument();
+    expect(within(matrix).getByText('merged 2026-06-02')).toBeInTheDocument();
+    expect(within(matrix).getByText('matched in: title, branch')).toBeInTheDocument();
+    expect(within(matrix).getByText('not counted — “prepares for”')).toBeInTheDocument();
+    const link = within(matrix).getByRole('link', { name: '#88' });
+    expect(link).toHaveAttribute('href', 'https://github.com/hiero-ledger/consensus/pull/88');
 
     await userEvent.click(cell); // same cell toggles closed
-    expect(within(matrix).queryByText("2 referencing PRs")).not.toBeInTheDocument();
+    expect(within(matrix).queryByText('2 referencing PRs')).not.toBeInTheDocument();
   });
 
-  it("cells without evidence do not open a panel", async () => {
+  it('cells without evidence do not open a panel', async () => {
     await openHips();
     const matrix = matrixCard();
 
-    await userEvent.click(within(matrix).getByText("44"));
+    await userEvent.click(within(matrix).getByText('44'));
     expect(within(matrix).queryByText(/referencing PR/)).not.toBeInTheDocument();
   });
 
-  it("board chip shows the info bar; the jump clears filters and flashes the row", async () => {
+  it('board chip shows the info bar; the jump clears filters and flashes the row', async () => {
     await openHips();
     const board = boardCard();
     const matrix = matrixCard();
 
     // Filter the target row out first, so the jump has to restore it.
-    await userEvent.click(within(matrix).getByRole("button", { name: "Deferred" }));
-    expect(within(matrix).queryByText("HIP-1200")).not.toBeInTheDocument();
+    await userEvent.click(within(matrix).getByRole('button', { name: 'Deferred' }));
+    expect(within(matrix).queryByText('HIP-1200')).not.toBeInTheDocument();
 
-    await userEvent.click(within(board).getByRole("button", { name: "HIP-1200" }));
-    expect(within(board).getByText("Throughput")).toBeInTheDocument();
-    await userEvent.click(within(board).getByRole("button", { name: "Show in coverage matrix ↓" }));
+    await userEvent.click(within(board).getByRole('button', { name: 'HIP-1200' }));
+    expect(within(board).getByText('Throughput')).toBeInTheDocument();
+    await userEvent.click(within(board).getByRole('button', { name: 'Show in coverage matrix ↓' }));
 
-    expect(within(matrix).getByText("3 rows")).toBeInTheDocument(); // filters cleared
-    const row = matrix.querySelector("#hipmx-row-1200");
-    expect(row?.className).toContain("flash");
+    expect(within(matrix).getByText('3 rows')).toBeInTheDocument(); // filters cleared
+    const row = matrix.querySelector('#hipmx-row-1200');
+    expect(row?.className).toContain('flash');
   });
 
-  it("the evidence table itself still renders as a section with hip formatting", async () => {
+  it('the evidence table itself still renders as a section with hip formatting', async () => {
     await openHips();
 
-    const evidenceCard = screen.getByText("Evidence (per PR)").closest(".tsec") as HTMLElement;
-    expect(within(evidenceCard).getAllByText("HIP-1200").length).toBeGreaterThan(0);
+    const evidenceCard = screen.getByText('Evidence (per PR)').closest('.tsec') as HTMLElement;
+    expect(within(evidenceCard).getAllByText('HIP-1200').length).toBeGreaterThan(0);
   });
 });
 
-describe("HIPs tab ordering", () => {
-  it("puts the views ahead of the chart galleries, then the tables", async () => {
+describe('HIPs tab ordering', () => {
+  it('puts the views ahead of the chart galleries, then the tables', async () => {
     await openHips();
 
     // Legacy order (pipelines/dashboard.py): custom sections + charts + tables.
-    const titles = screen.getAllByRole("heading", { level: 2 }).map((heading) => heading.textContent);
+    const titles = screen
+      .getAllByRole('heading', { level: 2 })
+      .map((heading) => heading.textContent);
     expect(titles).toEqual([
-      "Where specs sit in governance",
-      "Implementation coverage matrix",
-      "Evidence (per PR)",
+      'Where specs sit in governance',
+      'Implementation coverage matrix',
+      'Evidence (per PR)',
     ]);
   });
 });

--- a/web/src/test/safety.test.ts
+++ b/web/src/test/safety.test.ts
@@ -3,18 +3,18 @@
  * downloads, and link schemes the browser would execute.
  */
 
-import { describe, expect, it } from "vitest";
-import { csvSafe, safeUrl } from "../safety";
+import { describe, expect, it } from 'vitest';
+import { csvSafe, safeUrl } from '../safety';
 
-describe("csvSafe", () => {
-  it.each(["=1+1", "+1", "-1+1", "@SUM(A1)", "\tcmd", "\rcmd", "\ncmd"])(
-    "neutralises the formula trigger %j",
+describe('csvSafe', () => {
+  it.each(['=1+1', '+1', '-1+1', '@SUM(A1)', '\tcmd', '\rcmd', '\ncmd'])(
+    'neutralises the formula trigger %j',
     (value) => {
       expect(csvSafe(value)).toBe(`'${value}`);
     },
   );
 
-  it("neutralises an attacker-chosen PR title", () => {
+  it('neutralises an attacker-chosen PR title', () => {
     // Anyone can open a PR in a public repo and name it whatever they like;
     // that title reaches the evidence table and its CSV download verbatim.
     expect(csvSafe('=HYPERLINK("https://evil.test","click")')).toBe(
@@ -22,32 +22,32 @@ describe("csvSafe", () => {
     );
   });
 
-  it("leaves ordinary values and the empty-cell placeholder alone", () => {
-    expect(csvSafe("feat: add HIP-1200 support")).toBe("feat: add HIP-1200 support");
-    expect(csvSafe("-")).toBe("-");
-    expect(csvSafe(42)).toBe("42");
-    expect(csvSafe(null)).toBe("");
+  it('leaves ordinary values and the empty-cell placeholder alone', () => {
+    expect(csvSafe('feat: add HIP-1200 support')).toBe('feat: add HIP-1200 support');
+    expect(csvSafe('-')).toBe('-');
+    expect(csvSafe(42)).toBe('42');
+    expect(csvSafe(null)).toBe('');
   });
 });
 
-describe("safeUrl", () => {
-  it("allows the schemes real evidence links use", () => {
-    expect(safeUrl("https://github.com/hiero-ledger/repo/pull/1")).toBe(
-      "https://github.com/hiero-ledger/repo/pull/1",
+describe('safeUrl', () => {
+  it('allows the schemes real evidence links use', () => {
+    expect(safeUrl('https://github.com/hiero-ledger/repo/pull/1')).toBe(
+      'https://github.com/hiero-ledger/repo/pull/1',
     );
-    expect(safeUrl("http://example.test")).toBe("http://example.test");
-    expect(safeUrl("mailto:someone@example.test")).toBe("mailto:someone@example.test");
+    expect(safeUrl('http://example.test')).toBe('http://example.test');
+    expect(safeUrl('mailto:someone@example.test')).toBe('mailto:someone@example.test');
   });
 
-  it("rejects schemes that would execute in the page", () => {
-    expect(safeUrl("javascript:alert(1)")).toBeNull();
-    expect(safeUrl("JaVaScRiPt:alert(1)")).toBeNull();
-    expect(safeUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
-    expect(safeUrl("  javascript:alert(1)  ")).toBeNull();
+  it('rejects schemes that would execute in the page', () => {
+    expect(safeUrl('javascript:alert(1)')).toBeNull();
+    expect(safeUrl('JaVaScRiPt:alert(1)')).toBeNull();
+    expect(safeUrl('data:text/html,<script>alert(1)</script>')).toBeNull();
+    expect(safeUrl('  javascript:alert(1)  ')).toBeNull();
   });
 
-  it("rejects empty and unparseable values", () => {
-    expect(safeUrl("")).toBeNull();
-    expect(safeUrl("   ")).toBeNull();
+  it('rejects empty and unparseable values', () => {
+    expect(safeUrl('')).toBeNull();
+    expect(safeUrl('   ')).toBeNull();
   });
 });

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,6 +1,6 @@
-import "@testing-library/jest-dom/vitest";
-import { afterEach } from "vitest";
-import { cleanup } from "@testing-library/react";
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
 
 // jsdom doesn't implement scrollIntoView; the jump bar calls it on click.
 if (!Element.prototype.scrollIntoView) {
@@ -9,5 +9,5 @@ if (!Element.prototype.scrollIntoView) {
 
 afterEach(() => {
   cleanup();
-  window.location.hash = "";
+  window.location.hash = '';
 });

--- a/web/src/useDataTable.tsx
+++ b/web/src/useDataTable.tsx
@@ -4,7 +4,7 @@
  * wired in. Any view rendering API rows builds its table through this.
  */
 
-import { useMemo, useState } from "react";
+import { useMemo, useState } from 'react';
 import {
   createColumnHelper,
   getCoreRowModel,
@@ -12,14 +12,14 @@ import {
   getSortedRowModel,
   useReactTable,
   type Table,
-} from "@tanstack/react-table";
-import type { ColumnSpec, Row } from "./api";
-import { FormattedCell } from "./components/FormattedCell";
+} from '@tanstack/react-table';
+import type { ColumnSpec, Row } from './api';
+import { FormattedCell } from './components/FormattedCell';
 
 // Column meta this app attaches: whether the column holds numbers, which earns
 // it tabular figures so digits keep a constant width. Alignment itself is not
 // per-column — every cell centres (see the `th`/`td` rules).
-declare module "@tanstack/react-table" {
+declare module '@tanstack/react-table' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- interface merging requires the type params
   interface ColumnMeta<TData, TValue> {
     numeric?: boolean;
@@ -29,12 +29,12 @@ declare module "@tanstack/react-table" {
 /** Sortable value: raw for numbers, string otherwise (matches legacy sort). */
 function sortableValue(row: Row, key: string): number | string {
   const value = row[key];
-  if (typeof value === "number") return value;
-  return value === null || value === undefined ? "" : String(value);
+  if (typeof value === 'number') return value;
+  return value === null || value === undefined ? '' : String(value);
 }
 
 export function useDataTable(columns: ColumnSpec[], rows: Row[], columnsKey: string): Table<Row> {
-  const [filter, setFilter] = useState("");
+  const [filter, setFilter] = useState('');
   const helper = createColumnHelper<Row>();
   const tableColumns = useMemo(
     () =>
@@ -42,8 +42,10 @@ export function useDataTable(columns: ColumnSpec[], rows: Row[], columnsKey: str
         helper.accessor((row) => sortableValue(row, spec.key), {
           id: spec.key,
           header: spec.label,
-          cell: (context) => <FormattedCell value={context.row.original[spec.key]} format={spec.format} />,
-          meta: { numeric: spec.format === "number" },
+          cell: (context) => (
+            <FormattedCell value={context.row.original[spec.key]} format={spec.format} />
+          ),
+          meta: { numeric: spec.format === 'number' },
         }),
       ),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- columns derive from the key

--- a/web/src/useHashState.ts
+++ b/web/src/useHashState.ts
@@ -5,15 +5,15 @@
  * goes through this same hook.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useState } from 'react';
 
 export function useHashState(key: string, fallback: string): [string, (value: string) => void] {
   const read = () => new URLSearchParams(window.location.hash.slice(1)).get(key) ?? fallback;
   const [value, setValue] = useState(read);
   useEffect(() => {
     const onHash = () => setValue(read());
-    window.addEventListener("hashchange", onHash);
-    return () => window.removeEventListener("hashchange", onHash);
+    window.addEventListener('hashchange', onHash);
+    return () => window.removeEventListener('hashchange', onHash);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- read is stable per key/fallback
   }, [key, fallback]);
   const update = (next: string) => {

--- a/web/src/useSectionDocs.ts
+++ b/web/src/useSectionDocs.ts
@@ -7,8 +7,8 @@
  * reported by name, so the gap is visible rather than silent.
  */
 
-import { useEffect, useState } from "react";
-import { fetchSection, type SectionDoc, type SectionRef } from "./api";
+import { useEffect, useState } from 'react';
+import { fetchSection, type SectionDoc, type SectionRef } from './api';
 
 export interface LoadedSections {
   docs: SectionDoc[];
@@ -19,7 +19,11 @@ export interface LoadedSections {
 }
 
 export function useSectionDocs(refs: SectionRef[]): LoadedSections {
-  const [state, setState] = useState<LoadedSections>({ docs: [], failed: [], loading: refs.length > 0 });
+  const [state, setState] = useState<LoadedSections>({
+    docs: [],
+    failed: [],
+    loading: refs.length > 0,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -27,8 +31,10 @@ export function useSectionDocs(refs: SectionRef[]): LoadedSections {
     Promise.allSettled(refs.map((ref) => fetchSection(ref))).then((results) => {
       if (cancelled) return;
       setState({
-        docs: results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : [])),
-        failed: refs.filter((_ref, index) => results[index].status === "rejected").map((ref) => ref.title),
+        docs: results.flatMap((result) => (result.status === 'fulfilled' ? [result.value] : [])),
+        failed: refs
+          .filter((_ref, index) => results[index].status === 'rejected')
+          .map((ref) => ref.title),
         loading: false,
       });
     });

--- a/web/src/useViewDocs.ts
+++ b/web/src/useViewDocs.ts
@@ -5,8 +5,8 @@
  * rather than blanking the tab around it.
  */
 
-import { useEffect, useState } from "react";
-import { fetchView, type ViewDoc, type ViewRef } from "./api";
+import { useEffect, useState } from 'react';
+import { fetchView, type ViewDoc, type ViewRef } from './api';
 
 export interface LoadedViews {
   views: ViewDoc[];
@@ -25,7 +25,11 @@ export interface LoadedViews {
 }
 
 export function useViewDocs(refs: ViewRef[]): LoadedViews {
-  const [state, setState] = useState<LoadedViews>({ views: [], failed: [], loading: refs.length > 0 });
+  const [state, setState] = useState<LoadedViews>({
+    views: [],
+    failed: [],
+    loading: refs.length > 0,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -33,8 +37,10 @@ export function useViewDocs(refs: ViewRef[]): LoadedViews {
     Promise.allSettled(refs.map((ref) => fetchView(ref))).then((results) => {
       if (cancelled) return;
       setState({
-        views: results.flatMap((result) => (result.status === "fulfilled" ? [result.value] : [])),
-        failed: refs.filter((_ref, index) => results[index].status === "rejected").map((ref) => ref.title),
+        views: results.flatMap((result) => (result.status === 'fulfilled' ? [result.value] : [])),
+        failed: refs
+          .filter((_ref, index) => results[index].status === 'rejected')
+          .map((ref) => ref.title),
         loading: false,
       });
     });

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ]
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest/config" />
-import tailwindcss from "@tailwindcss/vite";
-import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 // The app deploys next to the data it renders: CI copies web/dist, the data
 // API, and the chart PNGs into one Pages site, so all URLs are base-relative.
@@ -9,17 +9,17 @@ import { defineConfig } from "vite";
 // (`python -m http.server 8642 -d outputs`, the existing dashboard-preview
 // launch config) — same layout, no copying.
 export default defineConfig({
-  base: "./",
+  base: './',
   plugins: [react(), tailwindcss()],
   server: {
     proxy: {
-      "/data": "http://localhost:8642",
-      "/charts": "http://localhost:8642",
+      '/data': 'http://localhost:8642',
+      '/charts': 'http://localhost:8642',
     },
   },
   test: {
-    environment: "jsdom",
-    setupFiles: ["src/test/setup.ts"],
+    environment: 'jsdom',
+    setupFiles: ['src/test/setup.ts'],
     css: false,
   },
 });


### PR DESCRIPTION
Fixes #430

`web/` already shipped an `oxlint` config (`.oxlintrc.json`) and a `lint`
script, but the CI lint workflow only ran Ruff/Pyright for the Python side —
TypeScript/React changes could merge with no lint gate at all.

## Changes
- Add a `web-lint` job to `.github/workflows/lint.yml` that runs `npm run lint`
  (oxlint) and a new `npm run format:check` (Prettier) on push/PR, mirroring
  how Ruff is enforced for the Python side.
- Add Prettier to `web/` (`.prettierrc.json`, `.prettierignore`) with
  `format` / `format:check` scripts, since oxlint doesn't format.
- Reformat the existing `web/` source with Prettier so `format:check` starts
  from a clean baseline (pure formatting — quote style, spacing; no logic
  changes).
- Document the web lint/format commands in `CONTRIBUTING.md`.

Left ESLint itself out of scope — oxlint already covers that role here and is
faster; this just finishes wiring what was already configured.

## Testing
- `npm run lint` (oxlint) — passes, warnings only, exit 0
- `npm run format:check` (Prettier) — passes after reformat
- `npm run test` (vitest) — 54/54 passing
- `npm run build` — builds cleanly