### PR TITLE
fix: stabilize organisation diversity charts

### DIFF
--- a/docs/affiliations.md
+++ b/docs/affiliations.md
@@ -26,8 +26,10 @@ The *Organisation diversity* charts are split into **role tabs**. Each tab draws
 population, keyed on the person's *highest* role anywhere in the org, so nobody is counted
 twice: the **104 maintainers** on the Maintainers tab, and the **133 people whose ceiling is
 write access** on the Committers tab. Curation coverage differs sharply between them —
-maintainers are **98%** resolved, committers **78%** — so each chart states its own known
-share and draws the unresolved as an explicit *Unknown* band rather than hiding them.
+maintainers are **98%** resolved, committers **78%**. The employer pie shows only resolved
+holders, so its percentages use the same resolved-population denominator as the concentration
+metrics. Unresolved holders remain visible in the affiliations and diversity tables, and each
+pipeline run logs the known share and warns if it falls below the configured floor.
 
 The dashboard reads this file directly (offline) — no network needed at render time.
 
@@ -85,7 +87,7 @@ The unknowns are the `"?"` rows (status `unknown`). To work through them:
 1. **Get the worklist** — filter the *Maintainer affiliations* or *Committer affiliations*
    table by `status = unknown`, or `grep ': "?"' src/hiero_analytics/data/affiliations.yaml`.
    Each row's comment has the name. The committer roster is where the bulk of the remaining
-   unknowns sit, and it is the one the *Unknown* band on the Committers tab is measuring.
+   unknowns sit, so check its known share before interpreting the Committers pie.
 2. **Find their employer** — check the gitignored audit CSV
    (`outputs/data/org/<org>/maintainer_affiliation_audit.csv`); it lists each unknown's weak
    signals: an unmapped org membership, a **LinkedIn URL** pointer, redacted email domains.

--- a/src/hiero_analytics/analysis/affiliation.py
+++ b/src/hiero_analytics/analysis/affiliation.py
@@ -246,24 +246,35 @@ def top_n_with_other(
     *,
     top_n: int = 6,
     always_keep: Collection[str] = (),
+    always_pool: Collection[str] = (),
 ) -> pd.DataFrame:
     """Fold a distribution to its top-N rows plus a single ``Other (k)`` row.
 
     Keeps a donut readable: the largest ``top_n`` slices stay, the rest collapse
     into one. Labels in ``always_keep`` survive the fold however small they are,
-    so a band the chart promises to show (``Unknown``) cannot silently disappear
-    into ``Other``; they do not consume the ``top_n`` budget. Returns the frame
-    unchanged when it already has ``top_n`` rows or fewer.
+    so a band the chart promises to show cannot silently disappear into
+    ``Other``; they do not consume the ``top_n`` budget. Labels in
+    ``always_pool`` are the mirror image: they always land in ``Other``, however
+    large, and never compete for a slot — which is how a non-employer band like
+    ``Independent`` is kept from displacing a real employer from the ranking.
+    Returns the frame unchanged when it already has ``top_n`` rows or fewer, and
+    when pooling would leave nothing ranked at all.
     """
     if distribution.empty:
         return distribution
     ordered = distribution.sort_values(value_col, ascending=False).reset_index(drop=True)
-    if len(ordered) <= top_n:
+    pooled = ordered[ordered[label_col].isin(always_pool)]
+    rankable = ordered[~ordered[label_col].isin(always_pool)]
+    # Pooling every row would leave a pie whose only slice is 'Other' — no
+    # information at all, so show the distribution as it stands instead.
+    if rankable.empty:
         return ordered
-    pinned = ordered[label_col].isin(always_keep)
-    rest = ordered[~pinned]
-    kept = pd.concat([rest.head(top_n), ordered[pinned]]).sort_values(value_col, ascending=False)
-    tail = rest.iloc[top_n:]
+    if pooled.empty and len(ordered) <= top_n:
+        return ordered
+    pinned = rankable[label_col].isin(always_keep)
+    rest = rankable[~pinned]
+    kept = pd.concat([rest.head(top_n), rankable[pinned]]).sort_values(value_col, ascending=False)
+    tail = pd.concat([rest.iloc[top_n:], pooled])
     if tail.empty:
         return kept.reset_index(drop=True)
     other = pd.DataFrame([{label_col: f"Other ({len(tail)})", value_col: int(tail[value_col].sum())}])

--- a/src/hiero_analytics/dashboard_spec/__init__.py
+++ b/src/hiero_analytics/dashboard_spec/__init__.py
@@ -20,7 +20,7 @@ from hiero_analytics.dashboard_spec import (
     onboarding,
     security,
 )
-from hiero_analytics.dashboard_spec._assembly import canonical_macro, merged
+from hiero_analytics.dashboard_spec._assembly import canonical_macro, merged, table_variants
 from hiero_analytics.dashboard_spec.metrics import METRIC_ANNOTATIONS
 
 # Macro (family) display order — the tab order the dashboard shows.
@@ -43,6 +43,7 @@ __all__ = [
     "PROJECT_ISSUES_URL",
     "TABLE_FAMILIES",
     "WIDE_CHARTS",
+    "table_variants",
 ]
 
 AFFILIATION_ISSUE_URL = governance.AFFILIATION_ISSUE_URL

--- a/src/hiero_analytics/dashboard_spec/_assembly.py
+++ b/src/hiero_analytics/dashboard_spec/_assembly.py
@@ -43,3 +43,20 @@ def merged(families: Sequence[ModuleType], attribute: str) -> dict:
             raise ValueError(f"{attribute} defined by multiple families: {sorted(overlap)}")
         result.update(entries)
     return result
+
+
+def table_variants(section: dict) -> list[dict]:
+    """A section's role variants as fully-resolved section dicts.
+
+    A section without ``variants`` is its own single variant, so every consumer
+    (the emitter, the metric loader, the output contract tests) can iterate one
+    shape. Each declared variant inherits the section's ``file``, ``title``,
+    ``description``, ``columns`` and ``periods`` and overrides what differs —
+    so the variant that matches the section restates nothing, and the one that
+    deviates (a differently-named count column, a differently-labelled first
+    column) declares only its own difference.
+    """
+    declared = section.get("variants")
+    if not declared:
+        return [section]
+    return [{**{key: value for key, value in section.items() if key != "variants"}, **variant} for variant in declared]

--- a/src/hiero_analytics/dashboard_spec/glossary.py
+++ b/src/hiero_analytics/dashboard_spec/glossary.py
@@ -93,7 +93,12 @@ TERMS: dict[str, str] = {
         "holds every resolved seat. Higher is more concentrated."
     ),
     "single employer": "flagged when one employer holds every resolved seat — a capture / bus-factor risk.",
-    "independent": "people with no named employer: solo contributors, or personal-email-only signals.",
+    "independent": (
+        "people with no named employer: solo contributors, or personal-email-only signals. They count towards "
+        "the resolved population, but they are not an employer, so the diversity pie pools them into 'Other' "
+        "instead of ranking them against real organisations; the per-repo mix chart and the diversity "
+        "tables still break them out on their own."
+    ),
     "unknown": (
         "people no public signal could place. Not the same as independent — it means *we could not tell*, "
         "so they are excluded from the share and concentration calculations rather than counted as solo. "

--- a/src/hiero_analytics/dashboard_spec/glossary.py
+++ b/src/hiero_analytics/dashboard_spec/glossary.py
@@ -97,8 +97,8 @@ TERMS: dict[str, str] = {
     "unknown": (
         "people no public signal could place. Not the same as independent — it means *we could not tell*, "
         "so they are excluded from the share and concentration calculations rather than counted as solo. "
-        "The organisation-diversity charts still show them as their own band, and state what share of the "
-        "population is known, so nothing is silently dropped."
+        "They remain visible as unknown rows in the affiliations and diversity tables, while the affiliation "
+        "coverage log and warning track how much of each role population is known."
     ),
     "committer": (
         "in the committer affiliations table, a person whose *highest* role anywhere is committer — write "
@@ -110,7 +110,7 @@ TERMS: dict[str, str] = {
         "two populations are disjoint (each person counts at their highest role), so the committer tab is "
         "the bench beneath the maintainers — if it spans more employers than the maintainer tab, diversity "
         "is more likely to improve as people are promoted. Curation is thinner for committers, so read its "
-        "unknown band and stated known-share before drawing conclusions. The team charts have no role tabs: "
+        "unknown rows and known share before drawing conclusions. The team charts have no role tabs: "
         "team membership is not a permission."
     ),
     "organisation mix": "the employers present in the group, largest first.",

--- a/src/hiero_analytics/dashboard_spec/governance.py
+++ b/src/hiero_analytics/dashboard_spec/governance.py
@@ -561,15 +561,20 @@ CHART_NOTES = {
     "triage_network.png": "Each bubble is a repository, sized by how many triage-role holders are active in it; two repos "
     "are linked when they share a triage holder (thicker line = more shared). Bubble colour is the "
     "repo's category.",
-    "affiliation_donut.png": "The share of resolved role-holders employed by the two largest organisations, with everyone else (smaller "
-    "orgs and solo 'Independent' contributors) pooled into 'Other' — the concentration at a glance. "
-    "People with no curated affiliation are excluded from the pie and its percentages. The known share "
-    "for each role is shown in the Governance metric tiles; check it before interpreting the slices. "
-    "The role tabs switch between maintainers and committers.",
+    "affiliation_donut.png": "The share of resolved role-holders employed by the two largest organisations, with everyone else "
+    "pooled into 'Other' — the concentration at a glance. Only employers are ranked: solo 'Independent' "
+    "contributors always pool into 'Other' rather than competing for a slice, so the named slices are "
+    "always the two largest employers. People with no curated affiliation are excluded from the pie and "
+    "its percentages. The known share for each role is shown in the Governance metric tiles; check it "
+    "before interpreting the slices. The per-repo mix chart below breaks 'Independent' out separately, "
+    "and the companion CSV keeps every organisation's own row. The role tabs switch between maintainers "
+    "and committers.",
     "affiliation_donut_committers.png": "The committer view of the same chart: people whose highest role anywhere is committer (write "
     "access, no maintainer seat), so this population never overlaps the maintainer tab. Curation is "
     "thinner here, so every percentage is a share of resolved committers only. The committer-affiliations "
-    "known tile states the current coverage; weigh the employer slices against that number.",
+    "known tile states the current coverage; weigh the employer slices against that number. Independents "
+    "are a larger share of this bench than of the maintainers, and they sit inside 'Other' — read the "
+    "affiliations table for the split.",
     "repo_affiliation_composition.png": "Each bar is a repository, normalised to 100% so the segments show each employer's share of that "
     "repo's role-holders. The dashed line marks 50%: a segment reaching past it means one employer holds "
     "the majority (an organisational bus-factor). Largest employers get their own colour, smaller ones "
@@ -666,8 +671,8 @@ CHART_METHODOLOGY = {
             "rows in the companion affiliations table so its known share can be assessed."
         ),
         (
-            "Keep the two largest resolved slices, fold everyone else into 'Other', and draw a filled pie of "
-            "their shares."
+            "Rank employers only, keep the two largest, and fold everyone else — the smaller employers and the "
+            "whole 'Independent' band — into a single 'Other' slice, then draw a filled pie of their shares."
         ),
     ],
     "affiliation_donut_committers.png": [
@@ -678,8 +683,9 @@ CHART_METHODOLOGY = {
         "Look up each committer's organisation in the same curated affiliations file, by the same priority order.",
         (
             "Count distinct resolved committers per organisation, pooling employer-less people as "
-            "'Independent'. Exclude unmapped people from the pie and use the unknown rows in the companion "
-            "table to assess the known share, which is materially lower than for maintainers."
+            "'Independent' and then, as on the maintainer tab, into 'Other' — only employers are ranked. "
+            "Exclude unmapped people from the pie and use the unknown rows in the companion table to assess "
+            "the known share, which is materially lower than for maintainers."
         ),
     ],
     "single_employer_teams_by_org.png": [

--- a/src/hiero_analytics/dashboard_spec/governance.py
+++ b/src/hiero_analytics/dashboard_spec/governance.py
@@ -107,7 +107,8 @@ CHART_MACRO = {
                     "seat anywhere), so the two benches can be compared: a committer bench spread across "
                     "more employers is the leading indicator that maintainer diversity will follow. The "
                     "first chart is the ecosystem-wide split by employer (solo contributors pooled as "
-                    "'Independent', unmapped people shown as their own 'Unknown' band rather than dropped); "
+                    "'Independent' and unmapped people excluded; use the affiliations tables to assess "
+                    "curation coverage); "
                     "the next two count the governance teams and the repositories that a single employer "
                     "solely controls (an organisational bus-factor); the last two break down each "
                     "repository's and each team's mix. The team charts are membership-based and so have no "
@@ -544,17 +545,16 @@ CHART_NOTES = {
     "triage_network.png": "Each bubble is a repository, sized by how many triage-role holders are active in it; two repos "
     "are linked when they share a triage holder (thicker line = more shared). Bubble colour is the "
     "repo's category.",
-    "affiliation_donut.png": "The share of role-holders employed by the two largest organisations, with everyone else (smaller "
+    "affiliation_donut.png": "The share of resolved role-holders employed by the two largest organisations, with everyone else (smaller "
     "orgs and solo 'Independent' contributors) pooled into 'Other' — the concentration at a glance. "
-    "People with no curated affiliation are shown as their own 'Unknown' slice rather than dropped, and "
-    "the title states what share of the population is known, so a small slice can be read against how "
-    "much of the roster is resolved. The role tabs switch between maintainers and committers; the full "
-    "breakdown is in the affiliations tables.",
+    "People with no curated affiliation are excluded from the pie and its percentages. The known share "
+    "is the affiliated plus independent rows as a proportion of the full affiliations table; check it "
+    "before interpreting the slices. The role tabs switch between maintainers and committers.",
     "affiliation_donut_committers.png": "The committer view of the same chart: people whose highest role anywhere is committer (write "
     "access, no maintainer seat), so this population never overlaps the maintainer tab. Curation is "
-    "thinner here, which is why the 'Unknown' slice is larger and the known share in the title matters "
-    "more — every percentage is a share of all committers, unknowns included, so weigh the employer "
-    "slices against how big the 'Unknown' one is.",
+    "thinner here, so every percentage is a share of resolved committers only. Calculate the known share "
+    "from the affiliated plus independent rows in the full committer affiliations table and weigh the "
+    "employer slices against that coverage.",
     "repo_affiliation_composition.png": "Each bar is a repository, normalised to 100% so the segments show each employer's share of that "
     "repo's role-holders. The dashed line marks 50%: a segment reaching past it means one employer holds "
     "the majority (an organisational bus-factor). Largest employers get their own colour, smaller ones "
@@ -647,12 +647,12 @@ CHART_METHODOLOGY = {
         ),
         (
             "Count distinct people per organisation; people with an identity but no employer are pooled as "
-            "'Independent', and people with no public signal form their own 'Unknown' slice — the chart's "
-            "total is the whole population, never a silently trimmed one."
+            "'Independent'. Exclude people with no public signal from the pie; they remain visible as unknown "
+            "rows in the companion affiliations table so its known share can be assessed."
         ),
         (
-            "Keep the two largest slices, fold everyone else into 'Other', draw a filled pie of their shares, "
-            "and state the share of the population with a known affiliation in the title."
+            "Keep the two largest resolved slices, fold everyone else into 'Other', and draw a filled pie of "
+            "their shares."
         ),
     ],
     "affiliation_donut_committers.png": [
@@ -662,9 +662,9 @@ CHART_METHODOLOGY = {
         ),
         "Look up each committer's organisation in the same curated affiliations file, by the same priority order.",
         (
-            "Count distinct committers per organisation, pooling employer-less people as 'Independent' and "
-            "unmapped people as 'Unknown'; the title states what share is known, which is materially lower "
-            "than for maintainers."
+            "Count distinct resolved committers per organisation, pooling employer-less people as "
+            "'Independent'. Exclude unmapped people from the pie and use the unknown rows in the companion "
+            "table to assess the known share, which is materially lower than for maintainers."
         ),
     ],
     "single_employer_teams_by_org.png": [

--- a/src/hiero_analytics/dashboard_spec/governance.py
+++ b/src/hiero_analytics/dashboard_spec/governance.py
@@ -322,7 +322,7 @@ SECTION_SPECS = [
     {
         "id": "affiliations",
         "file": "maintainer_affiliations.csv",
-        "title": "Maintainer affiliations — reference",
+        "title": "Organisation affiliations — reference",
         "description": (
             "Reference: each maintainer, the organisation they were mapped to, and how it was decided — "
             "'automated' (the resolver placed them from public signals) or 'manual' (a hand-correction). "
@@ -339,26 +339,33 @@ SECTION_SPECS = [
             ("status", "status"),
             ("method", "method"),
         ],
-    },
-    {
-        "id": "committeraffiliations",
-        "file": "committer_affiliations.csv",
-        "title": "Committer affiliations — reference",
-        "description": (
-            "The same reference as the maintainer table, for people whose highest role anywhere is "
-            "committer — write access, but no maintainer seat in any repository. The two populations are "
-            "disjoint, so nobody appears in both. Curation coverage is thinner here than for maintainers, "
-            "so expect more 'unknown' rows; each one resolved makes the committer diversity chart sharper. "
-            "To fix a mapping or resolve an unknown, edit its row in data/affiliations.yaml and append "
-            "'# manual: reason', or use 'Suggest a correction' to open an issue on the analytics repo."
-        ),
-        "action_url": AFFILIATION_ISSUE_URL,
-        "action_label": "Suggest a correction",
-        "columns": [
-            ("login", "committer"),
-            ("organisation", "organisation"),
-            ("status", "status"),
-            ("method", "method"),
+        # Role tabs, not two stacked cards: the populations are disjoint views
+        # of one reference table and are read against each other. Both variants
+        # declare the same column *keys*; only the first column's label differs,
+        # so the committer variant restates the list purely to relabel it.
+        "variants": [
+            {"id": "affiliations", "label": "Maintainers", "title": "Maintainer affiliations — reference"},
+            {
+                "id": "committeraffiliations",
+                "label": "Committers",
+                "title": "Committer affiliations — reference",
+                "file": "committer_affiliations.csv",
+                "description": (
+                    "The same reference as the Maintainers tab, for people whose highest role anywhere is "
+                    "committer — write access, but no maintainer seat in any repository. The two populations "
+                    "are disjoint, so nobody appears in both. Curation coverage is thinner here than for "
+                    "maintainers, so expect more 'unknown' rows; each one resolved makes the committer "
+                    "diversity chart sharper. To fix a mapping or resolve an unknown, edit its row in "
+                    "data/affiliations.yaml and append '# manual: reason', or use 'Suggest a correction' to "
+                    "open an issue on the analytics repo."
+                ),
+                "columns": [
+                    ("login", "committer"),
+                    ("organisation", "organisation"),
+                    ("status", "status"),
+                    ("method", "method"),
+                ],
+            },
         ],
     },
     {
@@ -366,7 +373,7 @@ SECTION_SPECS = [
         "file": "repo_affiliation_diversity.csv",
         # Deliberately not time-filterable (like the diversity charts):
         # diversity is a property of the roster, not of a window's activity.
-        "title": "Maintainer organisation diversity by repo",
+        "title": "Organisation diversity by repo",
         "description": (
             "Per repo: how many maintainers it has, how many distinct employers they span, the largest "
             "employer and its share of resolved (mapped) maintainers — the same definition as the team "
@@ -383,28 +390,37 @@ SECTION_SPECS = [
             ("unknown", "unknown"),
             ("organisations", "organisations"),
         ],
-    },
-    {
-        "id": "committerrepodiversity",
-        "file": "repo_affiliation_diversity_committers.csv",
-        # Deliberately not time-filterable — see repodiversity above.
-        "title": "Committer organisation diversity by repo",
-        "description": (
-            "The repo table above, over committers instead of maintainers: per repo, how many committers "
-            "it has, how many distinct employers they span, the largest employer and its share of resolved "
-            "committers, and the independent / unknown counts. Read it against the maintainer table — a "
-            "repo whose maintainers are single-employer but whose committers are not has a bench it could "
-            "promote from. The 'unknown' count is higher here, so weigh a single-employer reading against it."
-        ),
-        "columns": [
-            ("repo", "repo"),
-            ("committers", "committers", "number"),
-            ("distinct_orgs", "distinct orgs", "number"),
-            ("top_org", "largest org"),
-            ("top_org_pct", "largest org %", "number"),
-            ("independent", "independent"),
-            ("unknown", "unknown"),
-            ("organisations", "organisations"),
+        # Same role tabs as the affiliations table above. Here the two variants
+        # genuinely differ in shape: the count column is named for the role it
+        # counts ('maintainers' / 'committers') in each produced CSV. The
+        # variant declares its own column list rather than the API inventing a
+        # shared key, so each tab publishes its table exactly as produced.
+        "variants": [
+            {"id": "repodiversity", "label": "Maintainers", "title": "Maintainer organisation diversity by repo"},
+            {
+                "id": "committerrepodiversity",
+                "label": "Committers",
+                "title": "Committer organisation diversity by repo",
+                "file": "repo_affiliation_diversity_committers.csv",
+                "description": (
+                    "The Maintainers tab's table over committers instead of maintainers: per repo, how many "
+                    "committers it has, how many distinct employers they span, the largest employer and its "
+                    "share of resolved committers, and the independent / unknown counts. Read it against the "
+                    "Maintainers tab — a repo whose maintainers are single-employer but whose committers are "
+                    "not has a bench it could promote from. The 'unknown' count is higher here, so weigh a "
+                    "single-employer reading against it."
+                ),
+                "columns": [
+                    ("repo", "repo"),
+                    ("committers", "committers", "number"),
+                    ("distinct_orgs", "distinct orgs", "number"),
+                    ("top_org", "largest org"),
+                    ("top_org_pct", "largest org %", "number"),
+                    ("independent", "independent"),
+                    ("unknown", "unknown"),
+                    ("organisations", "organisations"),
+                ],
+            },
         ],
     },
     {
@@ -497,7 +513,7 @@ SECTION_GROUPS = [
     # reference table sits beside its repo-diversity breakdown.
     (
         "Organisation diversity",
-        ["affiliations", "repodiversity", "committeraffiliations", "committerrepodiversity", "teamdiversity"],
+        ["affiliations", "repodiversity", "teamdiversity"],
     ),
 ]
 SECTION_ORDER = [sid for _name, ids in SECTION_GROUPS for sid in ids]

--- a/src/hiero_analytics/dashboard_spec/governance.py
+++ b/src/hiero_analytics/dashboard_spec/governance.py
@@ -107,8 +107,8 @@ CHART_MACRO = {
                     "seat anywhere), so the two benches can be compared: a committer bench spread across "
                     "more employers is the leading indicator that maintainer diversity will follow. The "
                     "first chart is the ecosystem-wide split by employer (solo contributors pooled as "
-                    "'Independent' and unmapped people excluded; use the affiliations tables to assess "
-                    "curation coverage); "
+                    "'Independent' and unmapped people excluded; the Governance metric tiles report "
+                    "curation coverage for each role); "
                     "the next two count the governance teams and the repositories that a single employer "
                     "solely controls (an organisational bus-factor); the last two break down each "
                     "repository's and each team's mix. The team charts are membership-based and so have no "
@@ -548,13 +548,12 @@ CHART_NOTES = {
     "affiliation_donut.png": "The share of resolved role-holders employed by the two largest organisations, with everyone else (smaller "
     "orgs and solo 'Independent' contributors) pooled into 'Other' — the concentration at a glance. "
     "People with no curated affiliation are excluded from the pie and its percentages. The known share "
-    "is the affiliated plus independent rows as a proportion of the full affiliations table; check it "
-    "before interpreting the slices. The role tabs switch between maintainers and committers.",
+    "for each role is shown in the Governance metric tiles; check it before interpreting the slices. "
+    "The role tabs switch between maintainers and committers.",
     "affiliation_donut_committers.png": "The committer view of the same chart: people whose highest role anywhere is committer (write "
     "access, no maintainer seat), so this population never overlaps the maintainer tab. Curation is "
-    "thinner here, so every percentage is a share of resolved committers only. Calculate the known share "
-    "from the affiliated plus independent rows in the full committer affiliations table and weigh the "
-    "employer slices against that coverage.",
+    "thinner here, so every percentage is a share of resolved committers only. The committer-affiliations "
+    "known tile states the current coverage; weigh the employer slices against that number.",
     "repo_affiliation_composition.png": "Each bar is a repository, normalised to 100% so the segments show each employer's share of that "
     "repo's role-holders. The dashed line marks 50%: a segment reaching past it means one employer holds "
     "the majority (an organisational bus-factor). Largest employers get their own colour, smaller ones "

--- a/src/hiero_analytics/dashboard_spec/metrics.py
+++ b/src/hiero_analytics/dashboard_spec/metrics.py
@@ -111,6 +111,28 @@ METRIC_ANNOTATIONS: dict[str, dict] = {
             "Count the people whose highest role is triage.",
         ],
     },
+    "maintainer affiliations known": {
+        "note": (
+            "The share of maintainers whose affiliation is resolved to a named employer or Independent. "
+            "The organisation-diversity pie uses this resolved population as its denominator."
+        ),
+        "methodology": [
+            "Take every row in the maintainer affiliations reference table.",
+            "Count rows whose status is affiliated or independent.",
+            "Divide by all maintainer rows, including unknowns, and round to a whole percent.",
+        ],
+    },
+    "committer affiliations known": {
+        "note": (
+            "The share of highest-role committers whose affiliation is resolved to a named employer or "
+            "Independent. Read the committer organisation-diversity pie against this coverage."
+        ),
+        "methodology": [
+            "Take every row in the committer affiliations reference table.",
+            "Count rows whose status is affiliated or independent.",
+            "Divide by all committer rows, including unknowns, and round to a whole percent.",
+        ],
+    },
     "quiet permission-holders (180d+)": {
         "note": (
             "People holding a granted role who have had no tracked activity for 180 days or more — an "

--- a/src/hiero_analytics/export/data_api.py
+++ b/src/hiero_analytics/export/data_api.py
@@ -21,6 +21,13 @@ The published rows carry *exactly* the declared columns: an extra column a
 pipeline writes stays in the CSV rather than becoming an undeclared part of
 the API's shape.
 
+Role variants: a section whose spec declares ``variants`` publishes each one
+under ``variants`` and hoists the first to the top level, so the dashboard can
+render them as one tabbed card while a consumer that predates the field still
+reads the same ``columns``/``rows``. Each absorbed variant keeps its own
+document and its own manifest entry, tagged ``absorbed_by`` — merging two cards
+into one must not withdraw ids that consumers and shared links already resolve.
+
 Versioning: breaking shape changes (renamed keys, removed sections) bump the
 version directory so consumers migrate deliberately; additive changes land in
 place. ``v1`` is additive-only from here.
@@ -53,6 +60,7 @@ from hiero_analytics.dashboard_spec import (
     PROJECT_ISSUES_URL,
     TABLE_FAMILIES,
     WIDE_CHARTS,
+    table_variants,
 )
 from hiero_analytics.domain.periods import ACTIVITY_PERIODS
 from hiero_analytics.export.csv_safety import sanitize_csv_text
@@ -163,45 +171,97 @@ def _period_variants(section: dict, org: str, org_data_dir: Path) -> dict[str, l
     return variants
 
 
-def _section_document(section: dict, group_of: dict, org: str, org_data_dir: Path) -> dict | None:
-    """Build one section's API document, or None when its table wasn't produced."""
-    csv_path = org_data_dir / section["file"]
+def _variant_document(variant: dict, org: str, org_data_dir: Path) -> dict | None:
+    """One variant's payload, or None when its table wasn't produced."""
+    csv_path = org_data_dir / variant["file"]
     if not csv_path.exists():
         return None
-    frame = _contract_frame(section, pd.read_csv(csv_path), f"{org}/{section['file']}")
+    frame = _contract_frame(variant, pd.read_csv(csv_path), f"{org}/{variant['file']}")
     document = {
-        "id": section["id"],
-        "title": section["title"],
-        "description": section["description"],
-        "group": group_of.get(section["id"], ""),
-        "source": section["file"],
+        "id": variant["id"],
+        "title": variant["title"],
+        "description": variant["description"],
+        "source": variant["file"],
         # Column entries mirror the spec: (key, label) plus an optional display
         # format — serialized as objects so consumers need no tuple knowledge.
         "columns": [
             {"key": column[0], "label": column[1], **({"format": column[2]} if len(column) > 2 else {})}
-            for column in section["columns"]
+            for column in variant["columns"]
         ],
         "rows": _rows(frame),
         "row_count": len(frame),
     }
+    if label := variant.get("label"):
+        document["label"] = label
     # A section's call to action (e.g. the affiliations table's "Suggest a
     # correction" issue link) travels with the document.
-    if action_url := section.get("action_url"):
-        document["action"] = {"url": action_url, "label": section.get("action_label", "Suggest a correction")}
+    if action_url := variant.get("action_url"):
+        document["action"] = {"url": action_url, "label": variant.get("action_label", "Suggest a correction")}
     _stamp_freshness(document, csv_path)
-    if periods := _period_variants(section, org, org_data_dir):
+    if periods := _period_variants(variant, org, org_data_dir):
         document["periods"] = periods
     return document
 
 
+def _section_document(section: dict, group_of: dict, org: str, org_data_dir: Path) -> dict | None:
+    """Build one section's API document, or None when its table wasn't produced.
+
+    A role-tabbed section publishes each variant under ``variants`` *and*
+    hoists the first one to the top level, so a v1 consumer that knows nothing
+    about variants still reads the same ``columns``/``rows`` it always did.
+    """
+    documents = [
+        document
+        for variant in table_variants(section)
+        if (document := _variant_document(variant, org, org_data_dir)) is not None
+    ]
+    if not documents:
+        return None
+    # The card's heading is the section's own, role-neutral title; each variant
+    # keeps the role-specific one for its standalone document and CSV export.
+    document = {
+        **documents[0],
+        "id": section["id"],
+        "title": section["title"],
+        "group": group_of.get(section["id"], ""),
+    }
+    # One surviving variant is an ordinary single-table section: no tab row to
+    # render, so no reason to ship the wrapper.
+    if len(documents) > 1:
+        document["variants"] = documents
+    return document
+
+
+def variant_annotations(filename: str) -> dict:
+    """The note and methodology declared for one chart file, keyed by filename.
+
+    The lookup is per *file*, not per chart: a chart's tabs show different
+    populations (maintainers / committers) or different spans, and each has its
+    own entry in the spec. Selecting one entry per chart — as the emitter used
+    to — made every entry belonging to a non-first tab unreachable.
+    """
+    annotations = {}
+    if note := CHART_NOTES.get(filename):
+        annotations["note"] = note
+    if methodology := CHART_METHODOLOGY.get(filename):
+        annotations["methodology"] = methodology
+    return annotations
+
+
 def _chart_variant(org: str, chart_dir: Path, label: str, filename: str) -> dict:
-    """One chart variant, carrying its pixel size when it can be read.
+    """One chart variant, carrying its own explanation and pixel size.
 
     The dimensions let the browser reserve the image's box before the PNG
     arrives, so a page of charts doesn't shift under the reader as they load.
     An unreadable PNG simply ships without them rather than failing the emit.
+
+    Note and methodology are keyed by *filename*, so each tab carries the text
+    describing the population it actually shows. The chart-level fields below
+    remain as the fallback for a variant with no entry of its own (the period
+    tabs that share one explanation), which is also what a v1 consumer written
+    before these fields existed keeps reading.
     """
-    variant = {"label": label, "file": f"charts/org/{org}/{filename}"}
+    variant = {"label": label, "file": f"charts/org/{org}/{filename}", **variant_annotations(filename)}
     try:
         with Image.open(chart_dir / filename) as image:
             variant["width"], variant["height"] = image.width, image.height
@@ -289,19 +349,11 @@ def _org_chart_sections(org: str, org_data_dir: Path, org_dir: Path) -> list[dic
     return sections
 
 
-def _attach_download(section: dict, spec: dict, org: str, org_data_dir: Path, org_dir: Path) -> None:
-    """Copy a chart's declared companion CSV into the API tree and reference it.
-
-    The Pages deploy publishes only the API tree and the chart PNGs, so a CSV
-    the dashboard offers for download has to travel inside the API. The copy
-    keeps the raw ``outputs/data`` artifact untouched.
-    """
-    csv_name = spec.get("csv")
-    if not csv_name:
-        return
+def _copy_download(csv_name: str, org: str, org_data_dir: Path, org_dir: Path) -> dict | None:
+    """Copy one companion CSV into the API tree and describe it, or None."""
     csv_path = org_data_dir / csv_name
     if not csv_path.exists():
-        return
+        return None
     # This copy exists to be downloaded and opened in a spreadsheet, so it is
     # neutralised against formula injection; the artifact under outputs/data
     # stays verbatim for pandas consumers.
@@ -309,7 +361,51 @@ def _attach_download(section: dict, spec: dict, org: str, org_data_dir: Path, or
     download = {"name": csv_name, "path": f"{org}/{csv_name}"}
     if generated_at := _read_meta(csv_path).get("generated_at"):
         download["generated_at"] = generated_at
-    section["download"] = download
+    return download
+
+
+def _attach_download(section: dict, spec: dict, org: str, org_data_dir: Path, org_dir: Path) -> None:
+    """Copy a chart card's declared companion CSV(s) into the API and reference them.
+
+    The Pages deploy publishes only the API tree and the chart PNGs, so a CSV
+    the dashboard offers for download has to travel inside the API. The copy
+    keeps the raw ``outputs/data`` artifact untouched.
+
+    ``csv`` is one filename for a card whose tabs all read the same table, or a
+    ``{variant label: filename}`` map for a card whose tabs show different
+    populations — a single download on a role-tabbed card would hand the reader
+    the maintainer table while they are looking at committers. The frontend
+    offers the active tab's entry and hides the button where a tab has none.
+    """
+    declared = spec.get("csv")
+    if not declared:
+        return
+    if isinstance(declared, str):
+        if download := _copy_download(declared, org, org_data_dir, org_dir):
+            section["download"] = download
+        return
+    downloads = {
+        label: download
+        for label, csv_name in declared.items()
+        if (download := _copy_download(csv_name, org, org_data_dir, org_dir))
+    }
+    if downloads:
+        section["downloads"] = downloads
+
+
+def _write_section(document: dict, org: str, org_dir: Path) -> dict:
+    """Write one section document and return the manifest entry pointing at it."""
+    (org_dir / f"{document['id']}.json").write_text(json.dumps(document, indent=1), encoding="utf-8")
+    entry = {
+        "id": document["id"],
+        "macro": document["macro"],
+        "title": document["title"],
+        "row_count": document["row_count"],
+        "path": f"{org}/{document['id']}.json",
+    }
+    if absorbed_by := document.get("absorbed_by"):
+        entry["absorbed_by"] = absorbed_by
+    return entry
 
 
 def _org_views(org: str, org_data_dir: Path, org_dir: Path) -> list[dict]:
@@ -421,17 +517,22 @@ def emit_data_api() -> Path:
                 if document is None:
                     continue
                 document["macro"] = family.CHART_MACRO["name"]
-                path = org_dir / f"{document['id']}.json"
-                path.write_text(json.dumps(document, indent=1), encoding="utf-8")
-                sections.append(
-                    {
-                        "id": document["id"],
+                sections.append(_write_section(document, org, org_dir))
+                # A role-tabbed card absorbs what used to be sibling sections.
+                # Each absorbed variant keeps its own document *and* its own
+                # manifest entry, tagged with the card that now renders it:
+                # v1 is additive-only, so merging two cards into one must not
+                # withdraw ids that consumers — and shared `#widget=` links —
+                # already resolve. The dashboard skips these and reads the
+                # rows from the merged card's `variants` instead.
+                for variant in document.get("variants", [])[1:]:
+                    absorbed = {
+                        **variant,
+                        "group": document["group"],
                         "macro": document["macro"],
-                        "title": document["title"],
-                        "row_count": document["row_count"],
-                        "path": f"{org}/{document['id']}.json",
+                        "absorbed_by": document["id"],
                     }
-                )
+                    sections.append(_write_section(absorbed, org, org_dir))
         chart_sections = _org_chart_sections(org, org_data_dir, org_dir)
         views = _org_views(org, org_data_dir, org_dir)
         if sections or chart_sections or views:

--- a/src/hiero_analytics/export/macro_metrics.py
+++ b/src/hiero_analytics/export/macro_metrics.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pandas as pd
 
 from hiero_analytics.config.analysis import GONE_DARK_DAYS
+from hiero_analytics.dashboard_spec import table_variants
 from hiero_analytics.domain.periods import ACTIVITY_PERIODS
 from hiero_analytics.domain.roles import ROLE_PRIORITY
 
@@ -124,9 +125,18 @@ METRICS_BY_MACRO = {"Contributors": contributors_metrics, "Governance": governan
 
 
 def macro_metrics(macro_name: str, family, org_data_dir: Path) -> list:
-    """The macro's tiles computed from its section tables, or [] when none apply."""
+    """The macro's tiles computed from its section tables, or [] when none apply.
+
+    Keyed by section id, and by variant id for a role-tabbed section — a
+    variant that a card now renders as a tab is still its own table, and a tile
+    reading it must not go blank because the card it lives under was merged.
+    """
     builder = METRICS_BY_MACRO.get(macro_name)
     if builder is None:
         return []
-    loaded = {spec["id"]: _load(org_data_dir / spec["file"]) for spec in family.SECTION_SPECS}
+    loaded = {
+        variant["id"]: _load(org_data_dir / variant["file"])
+        for spec in family.SECTION_SPECS
+        for variant in table_variants(spec)
+    }
     return builder(loaded, org_data_dir)

--- a/src/hiero_analytics/export/macro_metrics.py
+++ b/src/hiero_analytics/export/macro_metrics.py
@@ -47,6 +47,15 @@ def _holders_by_highest_role(coverage: pd.DataFrame) -> dict[str, int]:
     return {role: int(counts.get(role, 0)) for role in _GRANTED_ROLES}
 
 
+def _known_affiliation_share(affiliations: pd.DataFrame) -> str | None:
+    """Known-affiliation share from a role's full reference table."""
+    if affiliations.empty or "status" not in affiliations:
+        return None
+    statuses = affiliations["status"].astype(str).str.lower()
+    known = int(statuses.isin({"affiliated", "independent"}).sum())
+    return _pct(known, len(statuses))
+
+
 def contributors_metrics(loaded: dict[str, pd.DataFrame], org_data_dir: Path) -> list:
     """Headline tiles for the Contributors macro: who shows up, and how.
 
@@ -86,6 +95,12 @@ def governance_metrics(loaded: dict[str, pd.DataFrame], org_data_dir: Path) -> l
     for role, label in (("maintainer", "maintainers"), ("committer", "committers"), ("triage", "triage")):
         if role in role_counts:
             metrics.append((label, role_counts[role]))
+    for section_id, label in (
+        ("affiliations", "maintainer affiliations known"),
+        ("committeraffiliations", "committer affiliations known"),
+    ):
+        if share := _known_affiliation_share(loaded.get(section_id, pd.DataFrame())):
+            metrics.append((label, share))
     # The gonedark table follows the shared period tabs, but this tile keeps its
     # fixed 180-day access-hygiene threshold. Quiet-for-a-month is a superset of
     # quiet-for-180-days, so the 30d variant filters down to it exactly; a blank

--- a/src/hiero_analytics/pipelines/affiliation.py
+++ b/src/hiero_analytics/pipelines/affiliation.py
@@ -18,6 +18,7 @@ fetch, so this stays cheap and deterministic.
 from __future__ import annotations
 
 import logging
+from collections import Counter
 
 from hiero_analytics.analysis.affiliation import (
     AFFILIATIONS_PATH,
@@ -70,33 +71,61 @@ ROLE_VARIANTS = [("maintainer", ""), ("committer", "_committers")]
 # Neutral greys for non-employer segments; named employers use the categorical
 # palette shared by every organisation-keyed chart in this pipeline.
 _SEGMENT_FIXED = {INDEPENDENT: "#94A3B8", OTHER_LABEL: "#CBD5E1", UNKNOWN_LABEL: "#E5E7EB"}
-_SEGMENT_PALETTE = ["#F97316", "#0EA5E9", "#14B8A6", "#8B5CF6", "#EF4444", "#F59E0B", "#EC4899"]
+# Twenty qualitative swatches derived from matplotlib's tab20 palette. The
+# neutral greys were replaced, and the darker hues come first so adjacent,
+# prominent employers stay easy to distinguish in dense stacked bars.
+_SEGMENT_PALETTE = [
+    "#1F77B4",
+    "#FF7F0E",
+    "#2CA02C",
+    "#D62728",
+    "#9467BD",
+    "#8C564B",
+    "#E377C2",
+    "#BCBD22",
+    "#17BECF",
+    "#393B79",
+    "#AEC7E8",
+    "#FFBB78",
+    "#98DF8A",
+    "#FF9896",
+    "#C5B0D5",
+    "#C49C94",
+    "#F7B6D2",
+    "#DBDB8D",
+    "#9EDAE5",
+    "#8C6D31",
+]
+
+
+def _fixed_segment_color(segment: str) -> str | None:
+    """The fixed grey for a non-employer segment, including folded Other labels."""
+    if segment in _SEGMENT_FIXED:
+        return _SEGMENT_FIXED[segment]
+    if segment.startswith("Other (") and segment.endswith(")") and segment[7:-1].isdigit():
+        return _SEGMENT_FIXED[OTHER_LABEL]
+    return None
 
 
 def _composition_colors(segments: list[str]) -> dict[str, str]:
-    """Return deterministic employer colours plus fixed non-employer greys."""
-
-    def fixed_color(segment: str) -> str | None:
-        if segment in _SEGMENT_FIXED:
-            return _SEGMENT_FIXED[segment]
-        if segment.startswith("Other (") and segment.endswith(")") and segment[7:-1].isdigit():
-            return _SEGMENT_FIXED[OTHER_LABEL]
-        return None
-
-    unique_segments = set(segments)
-    employers = sorted(segment for segment in unique_segments if fixed_color(segment) is None)
-    # The pipeline builds this map once from the full affiliation map, so a
-    # role's slice/seat order cannot change an employer's colour.
+    """Return prominence-ranked employer colours plus fixed non-employer greys."""
+    seat_counts = Counter(segments)
+    employers = sorted(
+        (segment for segment in seat_counts if _fixed_segment_color(segment) is None),
+        key=lambda segment: (-seat_counts[segment], segment.casefold(), segment),
+    )
+    # The full affiliation map is ranked once for the pipeline. Modulo remains
+    # an overflow fallback: collisions are possible beyond 20 employers, but
+    # the chart-visible employer head fits; dense compositions pool the tail.
     colors = {employer: _SEGMENT_PALETTE[index % len(_SEGMENT_PALETTE)] for index, employer in enumerate(employers)}
-    colors.update({segment: color for segment in unique_segments if (color := fixed_color(segment)) is not None})
+    colors.update({segment: color for segment in seat_counts if (color := _fixed_segment_color(segment)) is not None})
     return colors
 
 
 def _chart_colors(segments: list[str], organisation_colors: dict[str, str] | None) -> dict[str, str]:
-    """Select shared colours for a chart, filling generated neutral labels."""
-    colors = _composition_colors(segments)
-    if organisation_colors:
-        colors.update({segment: organisation_colors[segment] for segment in segments if segment in organisation_colors})
+    """Select shared colours for a chart, adding only generated neutral labels."""
+    colors = dict(organisation_colors or {})
+    colors.update({segment: color for segment in segments if (color := _fixed_segment_color(segment)) is not None})
     return colors
 
 
@@ -424,7 +453,7 @@ def main(org: str = ORG) -> None:
     team_membership = build_team_membership(config)
     affiliations = load_affiliations()
     manual_logins = load_manual_logins()
-    organisation_colors = _composition_colors([*affiliations.values(), *_SEGMENT_FIXED])
+    organisation_colors = _composition_colors(list(affiliations.values()))
 
     # One set of org-scoped views per role tab. Roles are resolved at each
     # person's *highest* role anywhere, so the populations are disjoint and agree

--- a/src/hiero_analytics/pipelines/affiliation.py
+++ b/src/hiero_analytics/pipelines/affiliation.py
@@ -67,22 +67,36 @@ logger = logging.getLogger(__name__)
 # tab never renames an existing artifact.
 ROLE_VARIANTS = [("maintainer", ""), ("committer", "_committers")]
 
-# Neutral greys for the non-employer segments of the per-repo composition; named
-# employers cycle through the categorical palette.
+# Neutral greys for non-employer segments; named employers use the categorical
+# palette shared by every organisation-keyed chart in this pipeline.
 _SEGMENT_FIXED = {INDEPENDENT: "#94A3B8", OTHER_LABEL: "#CBD5E1", UNKNOWN_LABEL: "#E5E7EB"}
 _SEGMENT_PALETTE = ["#F97316", "#0EA5E9", "#14B8A6", "#8B5CF6", "#EF4444", "#F59E0B", "#EC4899"]
 
 
 def _composition_colors(segments: list[str]) -> dict[str, str]:
-    """Fixed greys for non-employer segments; palette colours for the employers."""
-    colors: dict[str, str] = {}
-    cycle = 0
-    for segment in segments:
+    """Return deterministic employer colours plus fixed non-employer greys."""
+
+    def fixed_color(segment: str) -> str | None:
         if segment in _SEGMENT_FIXED:
-            colors[segment] = _SEGMENT_FIXED[segment]
-        else:
-            colors[segment] = _SEGMENT_PALETTE[cycle % len(_SEGMENT_PALETTE)]
-            cycle += 1
+            return _SEGMENT_FIXED[segment]
+        if segment.startswith("Other (") and segment.endswith(")") and segment[7:-1].isdigit():
+            return _SEGMENT_FIXED[OTHER_LABEL]
+        return None
+
+    unique_segments = set(segments)
+    employers = sorted(segment for segment in unique_segments if fixed_color(segment) is None)
+    # The pipeline builds this map once from the full affiliation map, so a
+    # role's slice/seat order cannot change an employer's colour.
+    colors = {employer: _SEGMENT_PALETTE[index % len(_SEGMENT_PALETTE)] for index, employer in enumerate(employers)}
+    colors.update({segment: color for segment in unique_segments if (color := fixed_color(segment)) is not None})
+    return colors
+
+
+def _chart_colors(segments: list[str], organisation_colors: dict[str, str] | None) -> dict[str, str]:
+    """Select shared colours for a chart, filling generated neutral labels."""
+    colors = _composition_colors(segments)
+    if organisation_colors:
+        colors.update({segment: organisation_colors[segment] for segment in segments if segment in organisation_colors})
     return colors
 
 
@@ -117,7 +131,17 @@ def _plot_grouped_heatmap(df, label_col, ylabel, filename, title, data_dir, char
 
 
 def _pie_chart(
-    distribution, label_col, value_col, center_label, title, output_path, *, top_n=6, donut=True, always_keep=()
+    distribution,
+    label_col,
+    value_col,
+    center_label,
+    title,
+    output_path,
+    *,
+    colors=None,
+    top_n=6,
+    donut=True,
+    always_keep=(),
 ):
     """Render a distribution as a pie/donut (top-N slices + 'Other'); skips empty frames."""
     folded = top_n_with_other(distribution, label_col, value_col, top_n=top_n, always_keep=always_keep)
@@ -129,32 +153,33 @@ def _pie_chart(
         value_col=value_col,
         title=title,
         output_path=output_path,
+        colors=_chart_colors(folded[label_col].astype(str).tolist(), colors),
         center_label=center_label if donut else None,
         donut=donut,
     )
 
 
-def _distribution_chart(classified, data_dir, charts_dir, *, suffix, title, value_col):
-    """Role-holders-by-organisation pie, including the unmapped as their own band."""
-    distribution = build_affiliation_distribution(classified, value_col=value_col, include_unknown=True)
+def _distribution_chart(classified, data_dir, charts_dir, *, suffix, title, value_col, colors=None):
+    """Role-holders-by-organisation pie over people with resolved affiliations."""
+    distribution = build_affiliation_distribution(classified, value_col=value_col, include_unknown=False)
     save_dataframe(distribution, data_dir / f"affiliation_distribution{suffix}.csv")
     # A filled pie of the two largest employers + 'Other' — the concentration at a glance.
-    # Unknown is pinned: it is usually too small to survive the fold, and the chart's
-    # whole claim is that the unmapped are visible rather than quietly dropped.
     _pie_chart(
         distribution,
         "organisation",
         value_col,
         value_col,
-        f"{title} — {known_share_pct(classified)}% have a known affiliation",
+        title,
         charts_dir / f"affiliation_donut{suffix}.png",
+        colors=colors,
         top_n=2,
         donut=False,
-        always_keep=(UNKNOWN_LABEL,),
     )
 
 
-def _repo_composition_chart(role_lookup, affiliations, data_dir, charts_dir, *, role, suffix, title):
+def _repo_composition_chart(
+    role_lookup, affiliations, data_dir, charts_dir, *, role, suffix, title, organisation_colors
+):
     """Per-repo organisation-mix stacked bar for one role's holders."""
     composition, segments = build_repo_org_composition(role_lookup, affiliations, role=role)
     if segments:
@@ -166,7 +191,7 @@ def _repo_composition_chart(role_lookup, affiliations, data_dir, charts_dir, *, 
             x_col="repo",
             stack_cols=segments,
             labels=segments,
-            colors=_composition_colors(segments),
+            colors=_chart_colors(segments, organisation_colors),
             title=title,
             force_horizontal=False,
             rotate_x=90,
@@ -178,7 +203,7 @@ def _repo_composition_chart(role_lookup, affiliations, data_dir, charts_dir, *, 
         )
 
 
-def _team_composition_chart(team_membership, affiliations, data_dir, charts_dir, *, suffix, title):
+def _team_composition_chart(team_membership, affiliations, data_dir, charts_dir, *, suffix, title, organisation_colors):
     """Per-team organisation-mix stacked bar for a (possibly active-filtered) membership."""
     composition, segments = build_team_org_composition(team_membership, affiliations)
     if segments:
@@ -190,7 +215,7 @@ def _team_composition_chart(team_membership, affiliations, data_dir, charts_dir,
             x_col="team",
             stack_cols=segments,
             labels=segments,
-            colors=_composition_colors(segments),
+            colors=_chart_colors(segments, organisation_colors),
             title=title,
             force_horizontal=False,
             rotate_x=90,
@@ -202,7 +227,7 @@ def _team_composition_chart(team_membership, affiliations, data_dir, charts_dir,
         )
 
 
-def _single_employer_chart(team_membership, affiliations, charts_dir, *, suffix, title):
+def _single_employer_chart(team_membership, affiliations, charts_dir, *, suffix, title, organisation_colors):
     """Single-employer teams by controlling org, as a bar (possibly active-filtered)."""
     diversity = build_team_affiliation_diversity(team_membership, affiliations)
     plot_and_save(
@@ -212,10 +237,11 @@ def _single_employer_chart(team_membership, affiliations, charts_dir, *, suffix,
         x_col="organisation",
         y_col="teams",
         title=title,
+        colors=organisation_colors,
     )
 
 
-def _repo_diversity_views(role_lookup, affiliations, data_dir, charts_dir, *, role, suffix, title):
+def _repo_diversity_views(role_lookup, affiliations, data_dir, charts_dir, *, role, suffix, title, organisation_colors):
     """Per-repo diversity table plus its single-employer-repos-by-org companion chart."""
     diversity = build_repo_affiliation_diversity(role_lookup, affiliations, role=role)
     save_dataframe(diversity, data_dir / f"repo_affiliation_diversity{suffix}.csv")
@@ -226,6 +252,8 @@ def _repo_diversity_views(role_lookup, affiliations, data_dir, charts_dir, *, ro
         x_col="organisation",
         y_col="repos",
         title=title,
+        colors=organisation_colors,
+        horizontal=True,
     )
     if not diversity.empty:
         logger.info(
@@ -298,7 +326,18 @@ def _write_activity_views(
     _write_activity_heatmaps(records, role_lookup, team_membership, affiliations, org_data_dir, org_charts_dir, org=org)
 
 
-def _write_role_views(role, suffix, role_lookup, affiliations, manual_logins, data_dir, charts_dir, *, org):
+def _write_role_views(
+    role,
+    suffix,
+    role_lookup,
+    affiliations,
+    manual_logins,
+    data_dir,
+    charts_dir,
+    *,
+    org,
+    organisation_colors,
+):
     """Every org-scoped view for one governance role: reference table, donut, mixes."""
     holders = highest_role_holders(role_lookup, role)
     plural = role_column(role)
@@ -352,6 +391,7 @@ def _write_role_views(role, suffix, role_lookup, affiliations, manual_logins, da
         suffix=suffix,
         title=f"{org} — {role} organisation diversity (distinct {plural} by employer)",
         value_col=plural,
+        colors=organisation_colors,
     )
     _repo_composition_chart(
         role_repos,
@@ -361,6 +401,7 @@ def _write_role_views(role, suffix, role_lookup, affiliations, manual_logins, da
         role=role,
         suffix=suffix,
         title=f"{org} — {role} organisation mix by repository",
+        organisation_colors=organisation_colors,
     )
     _repo_diversity_views(
         role_repos,
@@ -370,6 +411,7 @@ def _write_role_views(role, suffix, role_lookup, affiliations, manual_logins, da
         role=role,
         suffix=suffix,
         title=f"{org} — repositories with a single {role} employer, by controlling organisation",
+        organisation_colors=organisation_colors,
     )
 
 
@@ -382,6 +424,7 @@ def main(org: str = ORG) -> None:
     team_membership = build_team_membership(config)
     affiliations = load_affiliations()
     manual_logins = load_manual_logins()
+    organisation_colors = _composition_colors([*affiliations.values(), *_SEGMENT_FIXED])
 
     # One set of org-scoped views per role tab. Roles are resolved at each
     # person's *highest* role anywhere, so the populations are disjoint and agree
@@ -397,6 +440,7 @@ def main(org: str = ORG) -> None:
             org_data_dir,
             org_charts_dir,
             org=org,
+            organisation_colors=organisation_colors,
         )
 
     # Team views are role-agnostic (membership, not permissions), so they stay single-variant.
@@ -406,6 +450,7 @@ def main(org: str = ORG) -> None:
         org_charts_dir,
         suffix="",
         title=f"{org} — single-employer governance teams, by controlling organisation",
+        organisation_colors=organisation_colors,
     )
     _team_composition_chart(
         team_membership,
@@ -414,6 +459,7 @@ def main(org: str = ORG) -> None:
         org_charts_dir,
         suffix="",
         title=f"{org} — organisation mix by governance team (teams with 4+ resolved members)",
+        organisation_colors=organisation_colors,
     )
     team_diversity = build_team_affiliation_diversity(team_membership, affiliations)
     save_dataframe(team_diversity, org_data_dir / "team_affiliation_diversity.csv")

--- a/src/hiero_analytics/pipelines/affiliation.py
+++ b/src/hiero_analytics/pipelines/affiliation.py
@@ -171,9 +171,12 @@ def _pie_chart(
     top_n=6,
     donut=True,
     always_keep=(),
+    always_pool=(),
 ):
     """Render a distribution as a pie/donut (top-N slices + 'Other'); skips empty frames."""
-    folded = top_n_with_other(distribution, label_col, value_col, top_n=top_n, always_keep=always_keep)
+    folded = top_n_with_other(
+        distribution, label_col, value_col, top_n=top_n, always_keep=always_keep, always_pool=always_pool
+    )
     if folded.empty:
         return
     plot_pie(
@@ -193,6 +196,10 @@ def _distribution_chart(classified, data_dir, charts_dir, *, suffix, title, valu
     distribution = build_affiliation_distribution(classified, value_col=value_col, include_unknown=False)
     save_dataframe(distribution, data_dir / f"affiliation_distribution{suffix}.csv")
     # A filled pie of the two largest employers + 'Other' — the concentration at a glance.
+    # 'Independent' is pooled rather than ranked: it is the absence of an employer,
+    # so letting it take a slot would push a real employer out of the ranking (on the
+    # committer tab it outranks LimeChain). The full breakdown, Independent included,
+    # stays in the companion CSV and the affiliations table.
     _pie_chart(
         distribution,
         "organisation",
@@ -203,6 +210,7 @@ def _distribution_chart(classified, data_dir, charts_dir, *, suffix, title, valu
         colors=colors,
         top_n=2,
         donut=False,
+        always_pool=(INDEPENDENT,),
     )
 
 

--- a/src/hiero_analytics/plotting/bars.py
+++ b/src/hiero_analytics/plotting/bars.py
@@ -8,6 +8,7 @@ from typing import cast
 import pandas as pd
 from matplotlib.axes import Axes
 from matplotlib.patches import FancyBboxPatch, Patch, Rectangle
+from matplotlib.ticker import MaxNLocator
 
 from hiero_analytics.config.charts import (
     ANNOTATION_FONT_SIZE,
@@ -83,18 +84,22 @@ def _compute_horizontal_axis_limit(max_value: float, annotation_padding: float) 
 def _apply_bar_axis_layout(ax: Axes, values: pd.Series, *, horizontal: bool) -> None:
     """Shared axis treatment for bar charts: orientation, margins, value-axis limits.
 
-    Horizontal charts read top-down (inverted y) and reserve room on the right
-    for the end-of-bar total labels; vertical charts pin the value axis to zero.
+    Horizontal charts read top-down (inverted y); both orientations reserve room
+    after the largest value for the end-of-bar total labels.
     """
+    max_value = float(values.max()) if not values.empty else 0.0
+    padding = _compute_annotation_padding(max_value)
     if horizontal:
         ax.invert_yaxis()
-        max_value = float(values.max()) if not values.empty else 0.0
-        padding = _compute_annotation_padding(max_value)
         ax.margins(y=HORIZONTAL_Y_MARGIN, x=HORIZONTAL_X_MARGIN)
         ax.set_xlim(0, _compute_horizontal_axis_limit(max_value, padding))
     else:
         ax.margins(x=VERTICAL_X_MARGIN, y=VERTICAL_Y_MARGIN)
-        ax.set_ylim(bottom=0)
+        ax.set_ylim(0, _compute_horizontal_axis_limit(max_value, padding))
+
+    if not values.empty and all(float(value).is_integer() for value in values):
+        value_axis = ax.xaxis if horizontal else ax.yaxis
+        value_axis.set_major_locator(MaxNLocator(integer=True))
 
 
 def _stacked_bar_figsize(row_count: int, *, horizontal: bool, auto_height_for_horizontal: bool) -> tuple[float, float]:
@@ -212,6 +217,7 @@ def plot_bar(
     output_path: Path,
     rotate_x: int | None = None,
     colors: dict[str, str] | None = None,
+    horizontal: bool | None = None,
 ) -> None:
     """Plot a standard bar chart."""
     df = prepare_dataframe(df, x_col, y_col).copy()
@@ -221,7 +227,7 @@ def plot_bar(
         df = (
             df.sort_values(x_col) if is_numeric_or_datetime(df[x_col]) else df.sort_values(y_col, ascending=False)
         )  # Auto-switch to a more report-like horizontal layout for crowded categories.
-    horizontal = _should_use_horizontal(df, x_col, rotate_x)
+    use_horizontal = _should_use_horizontal(df, x_col, rotate_x) if horizontal is None else horizontal
 
     with figure_context() as (fig, ax):
         bar_colors = (
@@ -237,7 +243,7 @@ def plot_bar(
                 linewidth=0,
                 zorder=BAR_ZORDER,
             )
-            if horizontal
+            if use_horizontal
             else ax.bar(
                 df[x_col],
                 df[y_col],
@@ -249,19 +255,19 @@ def plot_bar(
         )
         patches = cast(list[Rectangle], list(bars.patches))
         _round_bar_patches(ax, patches)
-        _annotate_bar_totals(ax, patches, df[y_col], horizontal=horizontal)
+        _annotate_bar_totals(ax, patches, df[y_col], horizontal=use_horizontal)
 
-        _apply_bar_axis_layout(ax, df[y_col], horizontal=horizontal)
+        _apply_bar_axis_layout(ax, df[y_col], horizontal=use_horizontal)
 
         finalize_chart(
             fig=fig,
             ax=ax,
             title=title,
-            xlabel=y_col if horizontal else x_col,
-            ylabel="" if horizontal else y_col,
+            xlabel=y_col if use_horizontal else x_col,
+            ylabel="" if use_horizontal else y_col,
             output_path=output_path,
-            rotate_x=None if horizontal else rotate_x,
-            grid_axis="x" if horizontal else "y",
+            rotate_x=None if use_horizontal else rotate_x,
+            grid_axis="x" if use_horizontal else "y",
             record_count=len(df),
         )
 

--- a/src/hiero_analytics/plotting/bars.py
+++ b/src/hiero_analytics/plotting/bars.py
@@ -66,12 +66,13 @@ def _should_use_horizontal(df: pd.DataFrame, x_col: str, rotate_x: int | None) -
 
 
 def _compute_annotation_padding(max_value: float) -> float:
-    """Return label padding with a small fixed floor for low-count charts."""
-    return max(max_value * ANNOTATION_PADDING_RATIO, ANNOTATION_MIN_PADDING)
+    """Return label padding, scaling down the floor for very small counts."""
+    scaled_floor = min(ANNOTATION_MIN_PADDING, max_value * 0.1)
+    return max(max_value * ANNOTATION_PADDING_RATIO, scaled_floor)
 
 
-def _compute_horizontal_axis_limit(max_value: float, annotation_padding: float) -> float:
-    """Leave enough room for labels while keeping the horizontal axis compact."""
+def _compute_value_axis_limit(max_value: float, annotation_padding: float) -> float:
+    """Leave enough room for labels while keeping either value axis compact."""
     if max_value <= 0:
         return 1.0
 
@@ -92,10 +93,10 @@ def _apply_bar_axis_layout(ax: Axes, values: pd.Series, *, horizontal: bool) -> 
     if horizontal:
         ax.invert_yaxis()
         ax.margins(y=HORIZONTAL_Y_MARGIN, x=HORIZONTAL_X_MARGIN)
-        ax.set_xlim(0, _compute_horizontal_axis_limit(max_value, padding))
+        ax.set_xlim(0, _compute_value_axis_limit(max_value, padding))
     else:
         ax.margins(x=VERTICAL_X_MARGIN, y=VERTICAL_Y_MARGIN)
-        ax.set_ylim(0, _compute_horizontal_axis_limit(max_value, padding))
+        ax.set_ylim(0, _compute_value_axis_limit(max_value, padding))
 
     if not values.empty and all(float(value).is_integer() for value in values):
         value_axis = ax.xaxis if horizontal else ax.yaxis

--- a/tests/analysis/test_affiliation.py
+++ b/tests/analysis/test_affiliation.py
@@ -574,3 +574,28 @@ def test_load_affiliations_resolves_misiek_blocky_and_seanbohan(tmp_path):
 
     assert mapping == {"misiek-blocky": "BlockyDevs", "seanbohan": "Linux Foundation"}
     assert load_manual_logins(path) == {"misiek-blocky", "seanbohan"}
+
+
+def test_top_n_with_other_always_pools_named_labels():
+    """A pooled label folds into 'Other' however large, freeing the slot for an employer."""
+    distribution = pd.DataFrame(
+        {
+            "organisation": ["Hashgraph", "Independent", "LimeChain", "BlockyDevs"],
+            "maintainers": [34, 25, 20, 2],
+        }
+    )
+
+    folded = top_n_with_other(distribution, "organisation", "maintainers", top_n=2, always_pool=("Independent",))
+
+    assert folded["organisation"].tolist() == ["Hashgraph", "LimeChain", "Other (2)"]
+    # Independent is inside 'Other', not dropped: the total is still the population.
+    assert int(folded["maintainers"].sum()) == 81
+
+
+def test_top_n_with_other_keeps_frame_when_everything_is_pooled():
+    """Pooling every row would leave a single meaningless slice, so nothing folds."""
+    distribution = pd.DataFrame({"organisation": ["Independent"], "maintainers": [12]})
+
+    folded = top_n_with_other(distribution, "organisation", "maintainers", top_n=2, always_pool=("Independent",))
+
+    assert folded["organisation"].tolist() == ["Independent"]

--- a/tests/contracts/test_output_contract.py
+++ b/tests/contracts/test_output_contract.py
@@ -42,7 +42,7 @@ import hiero_analytics.pipelines.repo_growth as repo_growth_mod
 import hiero_analytics.pipelines.role_coverage as role_coverage_mod
 import hiero_analytics.pipelines.run_all as run_all
 import hiero_analytics.pipelines.scorecard as scorecard_mod
-from hiero_analytics.dashboard_spec import CHART_MACROS, TABLE_FAMILIES
+from hiero_analytics.dashboard_spec import CHART_MACROS, TABLE_FAMILIES, table_variants
 from hiero_analytics.data_sources.models import (
     CodeOwnersRecord,
     ContributorActivityRecord,
@@ -57,8 +57,13 @@ from hiero_analytics.data_sources.models import (
 )
 from hiero_analytics.domain.periods import ACTIVITY_PERIODS
 
-# Every table section across the table-bearing macros (Contributors, Governance).
-ALL_SECTION_SPECS = [spec for family in TABLE_FAMILIES.values() for spec in family.SECTION_SPECS]
+# Every table section across the table-bearing macros (Contributors, Governance),
+# flattened through its role variants: a variant the dashboard renders as a tab
+# is still its own produced CSV with its own id, columns and API document, so it
+# has to face the same production/coverage/orphan checks a top-level section does.
+ALL_SECTION_SPECS = [
+    variant for family in TABLE_FAMILIES.values() for spec in family.SECTION_SPECS for variant in table_variants(spec)
+]
 
 PRIMARY = "hiero-ledger"
 HACKERS = "hiero-hackers"

--- a/tests/dashboard_spec/test_spec_consistency.py
+++ b/tests/dashboard_spec/test_spec_consistency.py
@@ -13,7 +13,9 @@ from hiero_analytics.dashboard_spec import (
     MACRO_GLOSSARIES,
     TABLE_FAMILIES,
     WIDE_CHARTS,
+    table_variants,
 )
+from hiero_analytics.export.data_api import variant_annotations
 
 
 def _referenced_files() -> set[str]:
@@ -38,6 +40,32 @@ def test_chart_annotations_reference_existing_charts():
     assert set(CHART_NOTES) <= referenced, sorted(set(CHART_NOTES) - referenced)
     assert set(CHART_METHODOLOGY) <= referenced, sorted(set(CHART_METHODOLOGY) - referenced)
     assert referenced >= WIDE_CHARTS, sorted(WIDE_CHARTS - referenced)
+
+
+def test_every_chart_annotation_reaches_a_variant():
+    """Every note and methodology entry must reach the tab it was written for.
+
+    The emitter used to pick one entry per chart (the first listed filename
+    that happened to be keyed), so an entry belonging to any later tab was
+    dead text: the committer tabs rendered the maintainer note, and the period
+    tabs the all-time one. This walks the real spec through the emitter's own
+    per-variant lookup, so reverting to per-chart selection fails here rather
+    than shipping unreachable copy.
+    """
+    reached_notes, reached_methods = set(), set()
+    for macro in CHART_MACROS:
+        for specs in macro["charts"].values():
+            for spec in specs:
+                for _caption, variants in spec["files"]:
+                    for _label, filename in variants:
+                        annotations = variant_annotations(filename)
+                        if "note" in annotations:
+                            reached_notes.add(filename)
+                        if "methodology" in annotations:
+                            reached_methods.add(filename)
+
+    assert set(CHART_NOTES) == reached_notes, sorted(set(CHART_NOTES) ^ reached_notes)
+    assert set(CHART_METHODOLOGY) == reached_methods, sorted(set(CHART_METHODOLOGY) ^ reached_methods)
 
 
 def test_section_groups_match_section_specs():
@@ -154,7 +182,14 @@ def test_column_glossaries_cover_the_columns_their_tables_show():
             continue
         # Each glossary key may name several labels ("a / b / c").
         defined = {part.strip() for entry in glossary["terms"] for part in entry["term"].split("/")}
-        shown = {column[1] for spec in family.SECTION_SPECS for column in spec["columns"]}
+        # Through the role variants: a label that only appears on a tab is
+        # still a label the tab shows, and must still be explained.
+        shown = {
+            column[1]
+            for spec in family.SECTION_SPECS
+            for variant in table_variants(spec)
+            for column in variant["columns"]
+        }
         unexplained = shown - defined - SELF_EVIDENT
         assert not unexplained, f"{macro_name}: columns shown but not explained: {sorted(unexplained)}"
 

--- a/tests/export/test_data_api.py
+++ b/tests/export/test_data_api.py
@@ -280,11 +280,221 @@ def test_chart_sections_carry_presentation_structure(api_env: Path, tmp_path: Pa
     (section,) = manifest["orgs"][ORG]["chart_sections"]
     assert section["title"] == "Widget charts" and section["slideshow"] is True
     (chart,) = section["charts"]
-    # Only the produced variant is listed; note, methodology and wide survive.
-    assert chart["variants"] == [{"label": "All", "file": f"charts/org/{ORG}/widgets.png"}]
+    # Only the produced variant is listed. Its own note and methodology travel
+    # with it — the tab a reader is looking at has to explain that tab — and the
+    # chart-level copies stay as the fallback for a variant with no entry.
+    assert chart["variants"] == [
+        {
+            "label": "All",
+            "file": f"charts/org/{ORG}/widgets.png",
+            "note": "How to read widgets.",
+            "methodology": ["Step one."],
+        }
+    ]
     assert chart["note"] == "How to read widgets."
     assert chart["methodology"] == ["Step one."]
     assert chart["wide"] is True
+
+
+ROLE_TABBED_SECTION = {
+    "id": "widgets",
+    "file": "widgets.csv",
+    "title": "Widgets",
+    "description": "All widgets.",
+    "columns": [("name", "widget"), ("count", "count"), ("last_seen", "last seen", "date")],
+    "variants": [
+        {"id": "widgets", "label": "Maintainers"},
+        {
+            "id": "committerwidgets",
+            "label": "Committers",
+            "file": "committer_widgets.csv",
+            "description": "The committer view.",
+            # A genuinely different shape, not just a relabel: the count column
+            # is named for the role it counts in each produced CSV.
+            "columns": [("name", "widget"), ("committers", "committers"), ("last_seen", "last seen", "date")],
+        },
+    ],
+}
+
+
+def _write_committer_widgets(org_data: Path, frame: pd.DataFrame) -> None:
+    frame.to_csv(org_data / "committer_widgets.csv", index=False)
+
+
+def test_role_variants_publish_one_tabbed_document(api_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """A role-tabbed section ships every variant, hoisting the first to the top.
+
+    Hoisting is what keeps ``v1`` additive: a consumer that predates variants
+    reads the same ``columns``/``rows`` it always did, while the dashboard
+    renders one card with a tab per role instead of two stacked cards.
+    """
+    monkeypatch.setattr(data_api, "TABLE_FAMILIES", {"Testing": _family(ROLE_TABBED_SECTION)})
+    _write_widgets(api_env, pd.DataFrame({"name": ["a"], "count": [1], "last_seen": ["2026-07-01"]}))
+    _write_committer_widgets(api_env, pd.DataFrame({"name": ["b"], "committers": [2], "last_seen": ["2026-07-02"]}))
+
+    api_dir = emit_data_api().parent
+    document = json.loads((api_dir / ORG / "widgets.json").read_text())
+
+    assert document["rows"] == [{"name": "a", "count": 1, "last_seen": "2026-07-01"}]
+    assert [variant["label"] for variant in document["variants"]] == ["Maintainers", "Committers"]
+    committer = document["variants"][1]
+    assert committer["id"] == "committerwidgets"
+    assert committer["description"] == "The committer view."
+    assert committer["rows"] == [{"name": "b", "committers": 2, "last_seen": "2026-07-02"}]
+    assert [column["key"] for column in committer["columns"]] == ["name", "committers", "last_seen"]
+
+
+def test_absorbed_variants_keep_their_own_id_and_document(api_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """Merging two cards into one must not withdraw ids consumers already resolve.
+
+    ``v1`` is additive-only and shared ``#widget=`` links name section ids, so
+    an absorbed variant keeps its own document and manifest entry, tagged with
+    the card that now renders it.
+    """
+    monkeypatch.setattr(data_api, "TABLE_FAMILIES", {"Testing": _family(ROLE_TABBED_SECTION)})
+    _write_widgets(api_env, pd.DataFrame({"name": ["a"], "count": [1], "last_seen": ["2026-07-01"]}))
+    _write_committer_widgets(api_env, pd.DataFrame({"name": ["b"], "committers": [2], "last_seen": ["2026-07-02"]}))
+
+    manifest_path = emit_data_api()
+    manifest = json.loads(manifest_path.read_text())
+
+    entries = {section["id"]: section for section in manifest["orgs"][ORG]["sections"]}
+    assert set(entries) == {"widgets", "committerwidgets"}
+    assert "absorbed_by" not in entries["widgets"]
+    assert entries["committerwidgets"]["absorbed_by"] == "widgets"
+    assert entries["committerwidgets"]["row_count"] == 1
+    absorbed = json.loads((manifest_path.parent / ORG / "committerwidgets.json").read_text())
+    assert absorbed["rows"] == [{"name": "b", "committers": 2, "last_seen": "2026-07-02"}]
+    assert absorbed["group"] == "A group"
+
+
+def test_a_role_variant_without_its_table_is_simply_absent(api_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """One surviving variant is an ordinary single-table section, tab row and all."""
+    monkeypatch.setattr(data_api, "TABLE_FAMILIES", {"Testing": _family(ROLE_TABBED_SECTION)})
+    _write_widgets(api_env, pd.DataFrame({"name": ["a"], "count": [1], "last_seen": ["2026-07-01"]}))
+
+    manifest_path = emit_data_api()
+
+    document = json.loads((manifest_path.parent / ORG / "widgets.json").read_text())
+    assert "variants" not in document
+    assert [section["id"] for section in json.loads(manifest_path.read_text())["orgs"][ORG]["sections"]] == ["widgets"]
+
+
+def test_a_role_variant_faces_the_column_contract(api_env: Path, monkeypatch: pytest.MonkeyPatch):
+    """A renamed column in a variant's CSV fails the emit like the base table's."""
+    monkeypatch.setattr(data_api, "TABLE_FAMILIES", {"Testing": _family(ROLE_TABBED_SECTION)})
+    _write_widgets(api_env, pd.DataFrame({"name": ["a"], "count": [1], "last_seen": ["2026-07-01"]}))
+    _write_committer_widgets(api_env, pd.DataFrame({"name": ["b"], "commiters": [2], "last_seen": ["2026-07-02"]}))
+
+    with pytest.raises(DataApiContractError, match="committer_widgets.csv"):
+        emit_data_api()
+
+
+def test_chart_variants_carry_their_own_note_and_methodology(
+    api_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Each tab explains the population it shows, not the first tab's.
+
+    A role-tabbed card's committer note used to be unreachable: the emitter
+    picked one entry per chart, so the reader on the Committers tab was told
+    they were looking at maintainers.
+    """
+    monkeypatch.setattr(
+        data_api,
+        "CHART_MACROS",
+        [
+            {
+                "name": "Testing",
+                "charts": {
+                    ORG: [
+                        {
+                            "id": "w-chart",
+                            "title": "Widget charts",
+                            "description": "All widget charts.",
+                            "files": [
+                                ("Widgets", [("All", "widgets.png"), ("Active", "widgets_active.png")]),
+                            ],
+                        }
+                    ]
+                },
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        data_api,
+        "CHART_NOTES",
+        {"widgets.png": "Every widget.", "widgets_active.png": "Only the active ones."},
+    )
+    monkeypatch.setattr(
+        data_api,
+        "CHART_METHODOLOGY",
+        {"widgets.png": ["Count them all."], "widgets_active.png": ["Filter, then count."]},
+    )
+    chart_dir = tmp_path / "charts" / "org" / ORG
+    chart_dir.mkdir(parents=True)
+    for name in ("widgets.png", "widgets_active.png"):
+        (chart_dir / name).write_bytes(b"\x89PNG")
+    _write_widgets(api_env, pd.DataFrame({"name": ["a"], "count": [1], "last_seen": ["2026-07-01"]}))
+
+    manifest = json.loads(emit_data_api().read_text())
+
+    ((chart,),) = [section["charts"] for section in manifest["orgs"][ORG]["chart_sections"]]
+    assert [(variant["label"], variant["note"]) for variant in chart["variants"]] == [
+        ("All", "Every widget."),
+        ("Active", "Only the active ones."),
+    ]
+    assert chart["variants"][1]["methodology"] == ["Filter, then count."]
+
+
+def test_chart_downloads_can_be_declared_per_variant(api_env: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A role-tabbed card offers the active tab's companion CSV, not one for all.
+
+    Only the tabs with a declared companion appear, so the frontend can hide
+    the button where the active tab has none rather than handing the reader
+    another tab's table.
+    """
+    monkeypatch.setattr(
+        data_api,
+        "CHART_MACROS",
+        [
+            {
+                "name": "Testing",
+                "charts": {
+                    ORG: [
+                        {
+                            "id": "w-chart",
+                            "title": "Widget charts",
+                            "description": "All widget charts.",
+                            # "Active" declares a companion that no pipeline
+                            # produced, so it must not be offered at all.
+                            "csv": {"All": "widgets.csv", "Active": "widgets_active.csv"},
+                            "files": [
+                                ("Widgets", [("All", "widgets.png"), ("Active", "widgets_active.png")]),
+                            ],
+                        }
+                    ]
+                },
+            }
+        ],
+    )
+    chart_dir = tmp_path / "charts" / "org" / ORG
+    chart_dir.mkdir(parents=True)
+    for name in ("widgets.png", "widgets_active.png"):
+        (chart_dir / name).write_bytes(b"\x89PNG")
+    _write_widgets(api_env, pd.DataFrame({"name": ["a"], "count": [1], "last_seen": ["2026-07-01"]}))
+
+    manifest = json.loads(emit_data_api().read_text())
+
+    (section,) = manifest["orgs"][ORG]["chart_sections"]
+    assert "download" not in section
+    assert section["downloads"] == {
+        "All": {
+            "name": "widgets.csv",
+            "path": f"{ORG}/widgets.csv",
+            "generated_at": "2026-07-25T10:00:00+00:00",
+        }
+    }
+    assert (tmp_path / "data" / "api" / API_VERSION / ORG / "widgets.csv").exists()
 
 
 def test_manifest_ships_only_per_macro_glossaries(api_env: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/export/test_macro_metrics.py
+++ b/tests/export/test_macro_metrics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 
-from hiero_analytics.export.macro_metrics import contributors_metrics
+from hiero_analytics.export.macro_metrics import contributors_metrics, governance_metrics
 
 
 def test_contributor_metrics_tiles(tmp_path):
@@ -30,3 +30,23 @@ def test_contributor_metrics_tiles(tmp_path):
     assert metrics["open PRs %"] == "50%"
     assert metrics["give reviews %"] == "25%"
     assert metrics["completed a GFI %"] == "50%"
+
+
+def test_governance_metrics_include_live_affiliation_coverage(tmp_path):
+    """Known-share tiles use each role's full affiliations reference table."""
+    loaded = {
+        "repo": pd.DataFrame(
+            {
+                "user": ["alice", "bob"],
+                "granted_role": ["maintainer", "committer"],
+            }
+        ),
+        "teams": pd.DataFrame(),
+        "affiliations": pd.DataFrame({"status": ["affiliated", "independent", "unknown"]}),
+        "committeraffiliations": pd.DataFrame({"status": ["affiliated", "unknown", "unknown", "unknown"]}),
+    }
+
+    metrics = dict(governance_metrics(loaded, tmp_path))
+
+    assert metrics["maintainer affiliations known"] == "67%"
+    assert metrics["committer affiliations known"] == "25%"

--- a/tests/pipelines/test_affiliation_pipeline.py
+++ b/tests/pipelines/test_affiliation_pipeline.py
@@ -8,12 +8,15 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 import matplotlib
+import pandas as pd
 import pytest
+from PIL import Image
 
 matplotlib.use("Agg")
 
 import hiero_analytics.pipelines.affiliation as runner
 from hiero_analytics.data_sources.models import ContributorActivityRecord
+from hiero_analytics.export.data_api import _WIDE_ASPECT_ABOVE
 
 TEST_ORG = "test-org"
 
@@ -142,6 +145,82 @@ def test_main_creates_output_files(
     distribution = (data_dir / "affiliation_distribution.csv").read_text(encoding="utf-8")
     assert "Acme Corp" in distribution
     assert "Independent" in distribution
+
+
+def test_distribution_chart_excludes_unknown_and_keeps_coverage_out_of_title(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The downloadable distribution and pie both describe resolved holders only."""
+    data_dir, charts_dir = tmp_path / "data", tmp_path / "charts"
+    data_dir.mkdir()
+    charts_dir.mkdir()
+    classified = pd.DataFrame(
+        [
+            {"login": "alice", "organisation": "Acme Corp", "status": "affiliated"},
+            {"login": "bob", "organisation": None, "status": "unknown"},
+        ]
+    )
+    captured: dict = {}
+
+    def _capture_pie(_distribution, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(runner, "plot_pie", _capture_pie)
+
+    runner._distribution_chart(
+        classified,
+        data_dir,
+        charts_dir,
+        suffix="",
+        title="test-org — maintainer organisation diversity",
+        value_col="maintainers",
+    )
+
+    distribution = pd.read_csv(data_dir / "affiliation_distribution.csv")
+    assert "Unknown" not in distribution["organisation"].tolist()
+    assert "%" not in captured["title"]
+
+
+def test_distribution_chart_stays_below_dashboard_wide_aspect_threshold(tmp_path: Path):
+    """The standard donut title must keep the chart in its half-width gallery cell."""
+    data_dir, charts_dir = tmp_path / "data", tmp_path / "charts"
+    data_dir.mkdir()
+    charts_dir.mkdir()
+    classified = pd.DataFrame(
+        [
+            {"login": "alice", "organisation": "Hashgraph", "status": "affiliated"},
+            {"login": "bob", "organisation": "Hashgraph", "status": "affiliated"},
+            {"login": "carol", "organisation": "LimeChain", "status": "affiliated"},
+            {"login": "dave", "organisation": None, "status": "unknown"},
+        ]
+    )
+
+    runner._distribution_chart(
+        classified,
+        data_dir,
+        charts_dir,
+        suffix="",
+        title="hiero-ledger — maintainer organisation diversity (distinct maintainers by employer)",
+        value_col="maintainers",
+    )
+
+    with Image.open(charts_dir / "affiliation_donut.png") as image:
+        assert image.width / image.height < _WIDE_ASPECT_ABOVE
+
+
+def test_organisation_colors_are_stable_across_role_populations():
+    """Role-specific order and generated neutral bands must not alter organisation colours."""
+    shared = runner._composition_colors(
+        ["LimeChain", "Hashgraph", "BlockyDevs", "Independent", "Other orgs", "Unknown"]
+    )
+    maintainers = runner._chart_colors(["LimeChain", "Hashgraph", "Independent"], shared)
+    committers = runner._chart_colors(["Other (18)", "BlockyDevs", "Hashgraph", "Other orgs"], shared)
+
+    assert maintainers["Hashgraph"] == committers["Hashgraph"]
+    assert maintainers["Independent"] == runner._SEGMENT_FIXED["Independent"]
+    assert committers["Other orgs"] == runner._SEGMENT_FIXED["Other orgs"]
+    assert committers["Other (18)"] == runner._SEGMENT_FIXED["Other orgs"]
 
 
 def test_main_handles_empty_inputs(

--- a/tests/pipelines/test_affiliation_pipeline.py
+++ b/tests/pipelines/test_affiliation_pipeline.py
@@ -223,6 +223,56 @@ def test_organisation_colors_are_stable_across_role_populations():
     assert committers["Other (18)"] == runner._SEGMENT_FIXED["Other orgs"]
 
 
+def test_prominent_organisation_colors_are_distinct_and_stable():
+    """The chart-visible employer head must not collide or churn for a rare new org."""
+    employers = [employer for rank in range(10, 0, -1) for employer in [f"Employer {11 - rank:02d}"] * rank]
+
+    colors = runner._composition_colors(employers)
+    with_unrelated = runner._composition_colors([*employers, "Unrelated newcomer"])
+    top_ten = [f"Employer {index:02d}" for index in range(1, 11)]
+
+    assert len({colors[employer] for employer in top_ten}) == 10
+    assert with_unrelated["Employer 01"] == colors["Employer 01"]
+
+
+def test_repo_diversity_role_variants_are_wired_horizontal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Both role variants must pass the same explicit orientation to their chart."""
+    calls: list[dict] = []
+
+    def _capture_bar(_df, **kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(runner, "plot_bar", _capture_bar)
+    role_lookup = {
+        "test-org/core": {"alice": "maintainer", "amy": "maintainer"},
+        "test-org/tools": {"bob": "committer", "ben": "committer"},
+    }
+    affiliations = {
+        "alice": "Hashgraph",
+        "amy": "Hashgraph",
+        "bob": "BlockyDevs",
+        "ben": "BlockyDevs",
+    }
+
+    for role, suffix in runner.ROLE_VARIANTS:
+        runner._repo_diversity_views(
+            role_lookup,
+            affiliations,
+            tmp_path / "data",
+            tmp_path / "charts",
+            role=role,
+            suffix=suffix,
+            title=f"{role} diversity",
+            organisation_colors=runner._composition_colors(list(affiliations.values())),
+        )
+
+    assert [call["output_path"].name for call in calls] == [
+        "single_employer_repos_by_org.png",
+        "single_employer_repos_by_org_committers.png",
+    ]
+    assert all(call["horizontal"] is True for call in calls)
+
+
 def test_main_handles_empty_inputs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/pipelines/test_affiliation_pipeline.py
+++ b/tests/pipelines/test_affiliation_pipeline.py
@@ -387,3 +387,44 @@ def test_main_stays_quiet_when_curation_is_healthy(
         runner.main(TEST_ORG)
 
     assert not [record for record in caplog.records if "decayed" in record.getMessage()]
+
+
+def test_distribution_chart_pools_independents_into_other(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Only employers are ranked, but the companion CSV keeps Independent's own row."""
+    data_dir, charts_dir = tmp_path / "data", tmp_path / "charts"
+    data_dir.mkdir()
+    charts_dir.mkdir()
+    classified = pd.DataFrame(
+        [
+            {"login": "alice", "organisation": "Hashgraph", "status": "affiliated"},
+            {"login": "bob", "organisation": "Hashgraph", "status": "affiliated"},
+            {"login": "carol", "organisation": "Independent", "status": "independent"},
+            {"login": "dave", "organisation": "Independent", "status": "independent"},
+            {"login": "erin", "organisation": "LimeChain", "status": "affiliated"},
+            {"login": "frank", "organisation": "LimeChain", "status": "affiliated"},
+            {"login": "grace", "organisation": "BlockyDevs", "status": "affiliated"},
+        ]
+    )
+    captured: dict = {}
+
+    def _capture_frame(distribution, **_kwargs):
+        captured["frame"] = distribution
+
+    monkeypatch.setattr(runner, "plot_pie", _capture_frame)
+
+    runner._distribution_chart(
+        classified,
+        data_dir,
+        charts_dir,
+        suffix="",
+        title="test-org — maintainer organisation diversity",
+        value_col="maintainers",
+    )
+
+    slices = captured["frame"]["organisation"].tolist()
+    assert slices == ["Hashgraph", "LimeChain", "Other (2)"]
+    distribution = pd.read_csv(data_dir / "affiliation_distribution.csv")
+    assert "Independent" in distribution["organisation"].tolist()

--- a/tests/plotting/test_bars.py
+++ b/tests/plotting/test_bars.py
@@ -11,12 +11,27 @@ matplotlib.use("Agg")
 
 import matplotlib.pyplot as plt
 
+import hiero_analytics.plotting.bars as bars
 from hiero_analytics.plotting.bars import (
     _compute_annotation_padding,
     _round_bar_patches,
     plot_bar,
 )
 from hiero_analytics.plotting.base import create_figure
+
+
+def _capture_plot_bar(monkeypatch, tmp_path, df, *, horizontal):
+    captured = {}
+    monkeypatch.setattr(bars, "finalize_chart", lambda **kwargs: captured.update(kwargs))
+    plot_bar(
+        df,
+        x_col="organisation",
+        y_col="repos",
+        title="Single-employer repositories",
+        output_path=tmp_path / "bar.png",
+        horizontal=horizontal,
+    )
+    return captured
 
 
 def test_round_bar_patches_replaces_default_rectangles():
@@ -47,3 +62,32 @@ def test_plot_bar_writes_chart_file(tmp_path):
     plot_bar(bar_df, x_col="repo", y_col="count", title="Issues by Repository", output_path=output, rotate_x=30)
 
     assert output.exists() and output.stat().st_size > 0
+
+
+def test_plot_bar_orientation_override_and_heuristic_fallback(monkeypatch, tmp_path):
+    """Explicit orientation wins, while None retains the long-label heuristic."""
+    long_labels = pd.DataFrame({"organisation": ["DSR Corporation", "Hashgraph"], "repos": [2, 1]})
+    short_labels = pd.DataFrame({"organisation": ["Hashgraph", "BlockyDevs"], "repos": [2, 1]})
+
+    assert _capture_plot_bar(monkeypatch, tmp_path, long_labels, horizontal=False)["grid_axis"] == "y"
+    assert _capture_plot_bar(monkeypatch, tmp_path, short_labels, horizontal=True)["grid_axis"] == "x"
+    assert _capture_plot_bar(monkeypatch, tmp_path, long_labels, horizontal=None)["grid_axis"] == "x"
+    assert _capture_plot_bar(monkeypatch, tmp_path, short_labels, horizontal=None)["grid_axis"] == "y"
+
+
+def test_small_vertical_bar_keeps_annotations_inside_integer_value_axis(monkeypatch, tmp_path):
+    """Low count labels need headroom and count ticks must not become fractional."""
+    frame = pd.DataFrame({"organisation": ["Hashgraph", "BlockyDevs"], "repos": [2, 1]})
+
+    captured = _capture_plot_bar(monkeypatch, tmp_path, frame, horizontal=False)
+    ax = captured["ax"]
+    lower, upper = ax.get_ylim()
+    annotations = [text for text in ax.texts if text.get_text() in {"1", "2"}]
+
+    assert len(annotations) == 2
+    assert all(lower <= text.get_position()[1] <= upper for text in annotations)
+
+    captured["fig"].canvas.draw()
+    tick_labels = [label.get_text() for label in ax.get_yticklabels() if label.get_text()]
+    assert tick_labels
+    assert all("." not in label for label in tick_labels)

--- a/tests/plotting/test_bars.py
+++ b/tests/plotting/test_bars.py
@@ -50,6 +50,7 @@ def test_round_bar_patches_replaces_default_rectangles():
 
 def test_compute_annotation_padding_uses_ratio_with_floor():
     """Bar annotations should keep a minimum offset on small charts."""
+    assert _compute_annotation_padding(2) == pytest.approx(0.2)
     assert _compute_annotation_padding(10) == pytest.approx(0.75)
     assert _compute_annotation_padding(100) == pytest.approx(1.5)
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,9 +25,24 @@ const FLASH_MS = 1800; // shared link jump: flash the target for this long, then
 
 function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; macro: string }) {
   const entry = manifest.orgs[org];
+  // An absorbed section is a role variant another card renders as a tab. Its
+  // document still exists (v1 may not withdraw an id), but its rows travel
+  // inside the absorbing card, so fetching it would only duplicate the card.
   const refs = useMemo(
-    () => (entry.sections ?? []).filter((section) => section.macro === macro),
+    () =>
+      (entry.sections ?? []).filter((section) => section.macro === macro && !section.absorbed_by),
     [entry, macro],
+  );
+  // …and a link to one still has to land: `#widget=committeraffiliations`
+  // resolves to the card that absorbed it, which then activates that tab.
+  const absorbedInto = useMemo(
+    () =>
+      Object.fromEntries(
+        (entry.sections ?? [])
+          .filter((section) => section.absorbed_by)
+          .map((section) => [section.id, section.absorbed_by as string]),
+      ),
+    [entry],
   );
   const viewRefs = useMemo(
     () => (entry.views ?? []).filter((view) => view.macro === macro),
@@ -67,7 +82,7 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
   useEffect(() => {
     if (!settled || !widget) return;
     const jump = () => {
-      const target = document.getElementById(widget);
+      const target = document.getElementById(absorbedInto[widget] ?? widget);
       target?.scrollIntoView({ block: 'start', behavior: 'smooth' });
       target?.classList.add('flash');
       if (flashTimer.current) window.clearTimeout(flashTimer.current);
@@ -81,9 +96,9 @@ function OrgPanel({ org, manifest, macro }: { org: string; manifest: Manifest; m
         window.cancelAnimationFrame(raf as number);
       }
       if (flashTimer.current) window.clearTimeout(flashTimer.current);
-      document.getElementById(widget)?.classList.remove('flash');
+      document.getElementById(absorbedInto[widget] ?? widget)?.classList.remove('flash');
     };
-  }, [settled, widget]);
+  }, [settled, widget, absorbedInto]);
   const groups: Group[] = !settled
     ? []
     : names.flatMap((name): Group[] => {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -32,6 +32,13 @@ export interface SectionRef {
   title: string;
   row_count: number;
   path: string;
+  /**
+   * Set when this section is a role variant another card now renders as a tab.
+   * Its document still exists and still resolves — `v1` is additive-only, so a
+   * merged card may not withdraw an id — but the dashboard reads its rows from
+   * the absorbing section's `variants` rather than fetching it twice.
+   */
+  absorbed_by?: string;
 }
 
 export interface ChartVariant {
@@ -41,6 +48,14 @@ export interface ChartVariant {
    *  reserve the image's box so loading charts don't shift the page. */
   width?: number;
   height?: number;
+  /**
+   * This tab's own "how to read this" and derivation steps. A chart's tabs show
+   * different populations (maintainers / committers) or different spans, so the
+   * text has to follow the tab; the chart-level fields below remain the
+   * fallback for a tab with no entry of its own.
+   */
+  note?: string;
+  methodology?: string[];
 }
 
 export interface ChartSpec {
@@ -71,6 +86,13 @@ export interface ChartSection {
   charts: ChartSpec[];
   /** A companion CSV copied into the API tree, offered as a download. */
   download?: ChartDownload;
+  /**
+   * Companion CSVs per chart-variant label, for a card whose tabs show
+   * different populations. The card offers the one matching its shared variant
+   * axis and hides the button where that tab has none — a single download here
+   * would hand a reader on the Committers tab the maintainer table.
+   */
+  downloads?: Record<string, ChartDownload>;
 }
 
 /** A bespoke view the manifest lists by reference, like sections. */
@@ -203,6 +225,26 @@ export interface Manifest {
 
 export type Row = Record<string, unknown>;
 
+/**
+ * One role variant of a tabbed table section. Carries a full table of its own:
+ * the count column is named for the role it counts, so the variants differ in
+ * shape and not only in labels.
+ */
+export interface SectionVariant {
+  id: string;
+  label: string;
+  title: string;
+  description: string;
+  source: string;
+  columns: ColumnSpec[];
+  rows: Row[];
+  row_count: number;
+  action?: { url: string; label: string };
+  generated_at?: string;
+  stale?: boolean;
+  periods?: Record<string, Row[]>;
+}
+
 export interface SectionDoc {
   id: string;
   title: string;
@@ -217,6 +259,12 @@ export interface SectionDoc {
   generated_at?: string;
   stale?: boolean;
   periods?: Record<string, Row[]>;
+  /**
+   * Role tabs. The first variant is also hoisted to the fields above, so a
+   * consumer that predates this field reads the same table it always did.
+   * Present only when more than one variant was produced.
+   */
+  variants?: SectionVariant[];
 }
 
 /** Deploy-relative roots: the app, the API, and the chart PNGs ship together. */

--- a/web/src/components/ChartSectionCard.tsx
+++ b/web/src/components/ChartSectionCard.tsx
@@ -4,6 +4,13 @@
  * Active…), optional slideshow navigation, horizontal scroll for wide charts,
  * and a lightbox that reveals the "how to read this" note and step-by-step
  * methodology. The PNGs carry their provenance footer in the image itself.
+ *
+ * Charts that offer the *same* set of variant labels share one axis, owned by
+ * the card: the Organisation-diversity card has three Maintainers/Committers
+ * charts, and per-figure tabs let a reader end up comparing a maintainer donut
+ * with a committer repo mix while the description promised the tabs switch the
+ * view. Charts with any other label set (the period-tabbed cards elsewhere)
+ * keep their own tabs, so nothing else changes.
  */
 
 import { useState } from 'react';
@@ -11,21 +18,33 @@ import { chartUrl, fetchApiText, type ChartSection, type ChartSpec, type Manifes
 import { downloadCsvText } from '../csv';
 import { ChartLightbox, type LightboxContent } from './ChartLightbox';
 import { CopyLinkButton } from './CopyLinkButton';
+import { VariantTabs } from './VariantTabs';
+
+/**
+ * A chart's variant axis, identified by its ordered label set. Serialised
+ * rather than joined so no separator can be confused with a label.
+ */
+const axisOf = (chart: ChartSpec) => JSON.stringify(chart.variants.map((variant) => variant.label));
 
 function Figure({
   chart,
   onZoom,
   slide = false,
   stretch = false,
+  axis,
 }: {
   chart: ChartSpec;
   onZoom: (chart: ChartSpec, variant: number) => void;
   slide?: boolean;
   /** Span the full row even though the chart itself is half-width shaped. */
   stretch?: boolean;
+  /** Set when the card owns this chart's axis: it renders one tab row for all
+   *  the charts that share it, so this figure shows none of its own. */
+  axis?: { index: number; onSelect: (index: number) => void };
 }) {
-  const [variant, setVariant] = useState(0);
-  const active = chart.variants[Math.min(variant, chart.variants.length - 1)];
+  const [own, setOwn] = useState(0);
+  const variant = Math.min(axis ? axis.index : own, chart.variants.length - 1);
+  const active = chart.variants[variant];
   // A tall/square chart (a heatmap) in a ~340px gallery cell is illegible, but
   // the `wide` scroll-box treatment would shrink it to the box height instead.
   // It gets the full row with natural page flow: the dimensions ship with the
@@ -49,18 +68,13 @@ function Figure({
   );
   return (
     <figure className={slide ? 'slide' : fullRow ? 'chart wide' : 'chart'}>
-      {chart.variants.length > 1 && (
-        <div className="charttabs">
-          {chart.variants.map((option, index) => (
-            <button
-              key={option.label}
-              className={index === variant ? 'ctab active' : 'ctab'}
-              onClick={() => setVariant(index)}
-            >
-              {option.label}
-            </button>
-          ))}
-        </div>
+      {!axis && (
+        <VariantTabs
+          labels={chart.variants.map((option) => option.label)}
+          active={variant}
+          onSelect={setOwn}
+          ariaLabel={`${chart.title} view`}
+        />
       )}
       {chart.wide ? <div className="chartscroll">{img}</div> : img}
       <figcaption>{chart.title}</figcaption>
@@ -77,15 +91,41 @@ export function ChartSectionCard({
 }) {
   const [slide, setSlide] = useState(0);
   const [zoom, setZoom] = useState<LightboxContent | null>(null);
+  // One selection per shared axis, keyed by its label set.
+  const [shared, setShared] = useState<Record<string, number>>({});
 
   const onZoom = (chart: ChartSpec, variant: number) =>
     setZoom({
       src: chartUrl(chart.variants[variant].file),
       alt: chart.title,
-      note: chart.note,
-      methodology: chart.methodology,
+      // The tab's own text where it has one: on a role-tabbed chart the
+      // chart-level note describes maintainers, and showing it on the
+      // Committers tab misdescribes the population the reader is looking at.
+      note: chart.variants[variant].note ?? chart.note,
+      methodology: chart.variants[variant].methodology ?? chart.methodology,
     });
   const count = section.charts.length;
+
+  // An axis belongs to the card once two charts offer the same labels; a lone
+  // multi-variant chart keeps its own tabs where they sit, under its caption.
+  const axisCounts = new Map<string, number>();
+  for (const chart of section.charts) {
+    if (chart.variants.length > 1) {
+      const axis = axisOf(chart);
+      axisCounts.set(axis, (axisCounts.get(axis) ?? 0) + 1);
+    }
+  }
+  const sharedAxes = section.charts
+    .filter((chart) => chart.variants.length > 1 && (axisCounts.get(axisOf(chart)) ?? 0) > 1)
+    .map((chart) => ({ key: axisOf(chart), labels: chart.variants.map((v) => v.label) }))
+    .filter((axis, index, all) => all.findIndex((other) => other.key === axis.key) === index);
+  const axisFor = (chart: ChartSpec) =>
+    sharedAxes.some((axis) => axis.key === axisOf(chart))
+      ? {
+          index: shared[axisOf(chart)] ?? 0,
+          onSelect: (index: number) => setShared({ ...shared, [axisOf(chart)]: index }),
+        }
+      : undefined;
 
   // The gallery lays half-width charts out in pairs; full-row charts break the
   // pairing. A half-width chart stretches to the full row only when it is the
@@ -102,7 +142,17 @@ export function ChartSectionCard({
   const halfCount = section.charts.filter((chart) => !isFullRow(chart)).length;
   const stretched = section.charts.map((chart) => isFullRow(chart) || halfCount === 1);
 
-  const download = section.download;
+  // A card whose tabs show different populations declares a companion CSV per
+  // tab; offering one for the whole card would hand a reader on the Committers
+  // tab the maintainer table. No entry for the active tab means no button.
+  const activeLabel = sharedAxes.length
+    ? sharedAxes[0].labels[shared[sharedAxes[0].key] ?? 0]
+    : undefined;
+  const download = section.downloads
+    ? activeLabel
+      ? section.downloads[activeLabel]
+      : undefined
+    : section.download;
   return (
     <section className="card" id={section.id}>
       <h2>{section.title}</h2>
@@ -134,6 +184,17 @@ export function ChartSectionCard({
           </div>
         </div>
       </div>
+      {/* One row per shared axis, above the gallery: the card's charts switch
+          together, so the control belongs to the card and not to each figure. */}
+      {sharedAxes.map((axis) => (
+        <VariantTabs
+          key={axis.key}
+          labels={axis.labels}
+          active={shared[axis.key] ?? 0}
+          onSelect={(index) => setShared({ ...shared, [axis.key]: index })}
+          ariaLabel={`${section.title} view`}
+        />
+      ))}
       {section.slideshow && count > 1 ? (
         <div className="slideshow">
           <div className="slidenav">
@@ -152,12 +213,19 @@ export function ChartSectionCard({
             chart={section.charts[slide]}
             onZoom={onZoom}
             slide
+            axis={axisFor(section.charts[slide])}
           />
         </div>
       ) : (
         <div className="gallery">
           {section.charts.map((chart, index) => (
-            <Figure key={chart.title} chart={chart} onZoom={onZoom} stretch={stretched[index]} />
+            <Figure
+              key={chart.title}
+              chart={chart}
+              onZoom={onZoom}
+              stretch={stretched[index]}
+              axis={axisFor(chart)}
+            />
           ))}
         </div>
       )}

--- a/web/src/components/SectionTable.tsx
+++ b/web/src/components/SectionTable.tsx
@@ -1,18 +1,28 @@
 /**
  * One spec-listed section as a card: the shared card chrome, a
- * provenance-stamped CSV export, period tabs, and the sortable/filterable
- * table core.
+ * provenance-stamped CSV export, role tabs, period tabs, and the
+ * sortable/filterable table core.
+ *
+ * A section that publishes role `variants` renders as one tabbed card rather
+ * than a stack of near-identical ones. Each variant is a full table of its own
+ * — the count column is named for the role it counts — so the columns, rows,
+ * description, freshness stamp and export all follow the active tab.
  */
 
-import { useState } from 'react';
-import type { Manifest, SectionDoc } from '../api';
+import { useEffect, useState } from 'react';
+import type { Manifest, SectionDoc, SectionVariant } from '../api';
 import { safeUrl } from '../safety';
 import { useDataTable } from '../useDataTable';
+import { useHashState } from '../useHashState';
 import { CopyLinkButton } from './CopyLinkButton';
 import { CsvDownloadButton } from './CsvDownloadButton';
 import { DataTable } from './DataTable';
 import { PeriodTabs } from './PeriodTabs';
 import { SectionCard } from './SectionCard';
+import { VariantTabs } from './VariantTabs';
+
+/** The document's own table as a variant, for sections with no role tabs. */
+const soleVariant = (doc: SectionDoc): SectionVariant => ({ ...doc, label: '' });
 
 export function SectionTable({
   doc,
@@ -23,44 +33,73 @@ export function SectionTable({
   provenance: Manifest['provenance'];
   periodLabels?: Record<string, string>;
 }) {
+  const variants = doc.variants ?? [soleVariant(doc)];
+  // A shared link names a section id, and an absorbed variant kept its own —
+  // `#widget=committeraffiliations` has to land on this card with the
+  // Committers tab active, not on the maintainer table the card opens with.
+  const [widget] = useHashState('widget', '');
+  const [index, setIndex] = useState(() =>
+    Math.max(
+      0,
+      variants.findIndex((v) => v.id === widget),
+    ),
+  );
   const [period, setPeriod] = useState<string | null>(null);
-  const rows = period && doc.periods ? doc.periods[period] : doc.rows;
-  const table = useDataTable(doc.columns, rows, doc.id);
+  useEffect(() => {
+    const linked = variants.findIndex((variant) => variant.id === widget);
+    if (linked >= 0) setIndex(linked);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- variants derive from the doc
+  }, [widget, doc]);
+
+  const active = variants[Math.min(index, variants.length - 1)];
+  // The tabs carry independent row sets, so a period the previous tab offered
+  // may not exist on this one; fall back to its all-time rows rather than
+  // rendering an undefined table.
+  const rows = (period && active.periods?.[period]) || active.rows;
+  const table = useDataTable(active.columns, rows, active.id);
   const shown = table.getRowModel().rows.length;
-  const action = doc.action ? safeUrl(doc.action.url) : null;
+  const action = active.action ? safeUrl(active.action.url) : null;
 
   return (
     <SectionCard
       id={doc.id}
       title={doc.title}
       badge={shown === rows.length ? `${rows.length} rows` : `${shown} of ${rows.length}`}
-      description={doc.description}
-      generatedAt={doc.generated_at}
-      stale={doc.stale}
+      description={active.description}
+      generatedAt={active.generated_at}
+      stale={active.stale}
       actions={
         <>
-          <CopyLinkButton sectionId={doc.id} />
+          {/* The link names the active tab, so what a reader shares is what
+              they are looking at. */}
+          <CopyLinkButton sectionId={active.id} />
           {action && (
             <a className="dl" href={action} target="_blank" rel="noopener noreferrer">
-              {doc.action?.label}
+              {active.action?.label}
             </a>
           )}
           <CsvDownloadButton
             provenance={provenance}
             payload={() => ({
-              name: doc.id,
-              title: doc.title,
-              columns: doc.columns,
+              name: active.id,
+              title: active.title,
+              columns: active.columns,
               rows: table.getRowModel().rows.map((row) => row.original),
               total: rows.length,
-              dataAsOf: doc.generated_at,
+              dataAsOf: active.generated_at,
             })}
           />
         </>
       }
     >
+      <VariantTabs
+        labels={variants.map((variant) => variant.label)}
+        active={index}
+        onSelect={setIndex}
+        ariaLabel="Role"
+      />
       <PeriodTabs
-        periods={Object.keys(doc.periods ?? {})}
+        periods={Object.keys(active.periods ?? {})}
         active={period}
         onChange={setPeriod}
         labels={periodLabels}

--- a/web/src/components/VariantTabs.tsx
+++ b/web/src/components/VariantTabs.tsx
@@ -1,0 +1,42 @@
+/**
+ * A row of exclusive variant tabs, in the existing `.charttabs` / `.ctab`
+ * vocabulary. Used for a chart's own tabs, for a card's shared role axis, and
+ * for a table's role tabs — one component so the three cannot drift into three
+ * tab styles.
+ *
+ * Deliberately *not* `PeriodTabs`: that carries an "All time" null state, which
+ * a role axis has no equivalent of (there is no "all roles" table). Keeping the
+ * two visually distinct is also what lets a reader tell the axes apart on a
+ * table that has both.
+ */
+
+export function VariantTabs({
+  labels,
+  active,
+  onSelect,
+  ariaLabel,
+}: {
+  labels: string[];
+  active: number;
+  onSelect: (index: number) => void;
+  ariaLabel: string;
+}) {
+  if (labels.length < 2) {
+    return null;
+  }
+  return (
+    <div className="charttabs" role="group" aria-label={ariaLabel}>
+      {labels.map((label, index) => (
+        <button
+          key={label}
+          type="button"
+          className={index === active ? 'ctab active' : 'ctab'}
+          aria-pressed={index === active}
+          onClick={() => onSelect(index)}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -177,6 +177,181 @@ describe('Charts', () => {
   });
 });
 
+describe('Organisation diversity card (#435)', () => {
+  const openDiversity = async () => {
+    render(<App />);
+    await screen.findByRole('button', { name: 'Diversity' });
+    await userEvent.click(screen.getByRole('button', { name: 'Diversity' }));
+    return await screen.findByText('Organisation diversity');
+  };
+
+  const chartSrc = (title: string) => screen.getByAltText(title).getAttribute('src');
+
+  it('gives the card one role axis, so every role-tabbed chart switches together', async () => {
+    await openDiversity();
+
+    // One tab row for the card, not one per chart: three charts, two of which
+    // share the axis, must not be able to disagree about the active role.
+    const axes = screen.getAllByRole('group', { name: 'Organisation diversity view' });
+    expect(axes).toHaveLength(1);
+    expect(chartSrc('Role-holders by organisation')).toContain('affiliation_donut.png');
+    expect(chartSrc('Single-employer repos by org')).toContain('single_employer_repos_by_org.png');
+
+    await userEvent.click(within(axes[0]).getByRole('button', { name: 'Committers' }));
+
+    expect(chartSrc('Role-holders by organisation')).toContain('affiliation_donut_committers.png');
+    expect(chartSrc('Single-employer repos by org')).toContain(
+      'single_employer_repos_by_org_committers.png',
+    );
+    // The chart with no role axis is untouched by the card's tabs.
+    expect(chartSrc('Single-employer teams by org')).toContain('single_employer_teams_by_org.png');
+  });
+
+  it('leaves a chart with its own variant set on its own tabs', async () => {
+    // The period-tabbed pipeline card shares no axis with anything, so its
+    // tabs stay under the figure and keep their own state.
+    await openGovernance();
+
+    expect(
+      screen.queryByRole('group', { name: 'Maintainer pipeline view' }),
+    ).not.toBeInTheDocument();
+    const own = screen.getByRole('group', { name: 'Unique active contributors by role view' });
+    expect(within(own).getByRole('button', { name: 'By year' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('shows the active tab’s note and methodology in the lightbox', async () => {
+    await openDiversity();
+    const axis = screen.getByRole('group', { name: 'Organisation diversity view' });
+
+    await userEvent.click(within(axis).getByRole('button', { name: 'Committers' }));
+    await userEvent.click(screen.getByAltText('Role-holders by organisation'));
+
+    // The committer tab must describe committers — it used to show the
+    // maintainer note, which misdescribed its own population.
+    const lightbox = await screen.findByRole('dialog');
+    expect(within(lightbox).getByText('The committer bench by employer.')).toBeInTheDocument();
+    expect(within(lightbox).getByText('Count committers.')).toBeInTheDocument();
+    expect(
+      within(lightbox).queryByText('The maintainer bench by employer.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('downloads the active tab’s companion CSV', async () => {
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+    vi.stubGlobal(
+      'URL',
+      Object.assign(Object.create(URL), {
+        createObjectURL: () => 'blob:test',
+        revokeObjectURL: () => {},
+      }),
+    );
+    await openDiversity();
+    const axis = screen.getByRole('group', { name: 'Organisation diversity view' });
+    const card = screen.getByText('Organisation diversity').closest('section') as HTMLElement;
+
+    await userEvent.click(within(axis).getByRole('button', { name: 'Committers' }));
+    await userEvent.click(within(card).getByRole('button', { name: 'Download CSV' }));
+
+    await vi.waitFor(() =>
+      expect(
+        vi
+          .mocked(fetch)
+          .mock.calls.some(([url]) => String(url).endsWith('committer_affiliations.csv')),
+      ).toBe(true),
+    );
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([url]) => String(url).endsWith('maintainer_affiliations.csv')),
+    ).toBe(false);
+  });
+});
+
+describe('Role-tabbed tables (#435)', () => {
+  const openDiversity = async () => {
+    render(<App />);
+    await screen.findByRole('button', { name: 'Diversity' });
+    await userEvent.click(screen.getByRole('button', { name: 'Diversity' }));
+    return await screen.findByText('Organisation affiliations — reference');
+  };
+
+  it('renders one tabbed card instead of two stacked ones', async () => {
+    await openDiversity();
+
+    // The absorbed section is not a card of its own any more…
+    expect(screen.queryByText('Committer affiliations — reference')).not.toBeInTheDocument();
+    // …and its document is never fetched: its rows travel inside this card.
+    expect(
+      vi
+        .mocked(fetch)
+        .mock.calls.some(([url]) => String(url).endsWith('committeraffiliations.json')),
+    ).toBe(false);
+
+    const roles = screen.getByRole('group', { name: 'Role' });
+    expect(within(roles).getByRole('button', { name: 'Maintainers' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.queryByText('dave')).not.toBeInTheDocument();
+  });
+
+  it('swaps rows, columns and the freshness stamp with the tab', async () => {
+    await openDiversity();
+    const roles = screen.getByRole('group', { name: 'Role' });
+    const table = screen.getByRole('table');
+
+    expect(within(table).getByText('maintainer')).toBeInTheDocument();
+
+    await userEvent.click(within(roles).getByRole('button', { name: 'Committers' }));
+
+    // The count column is named for the role it counts, so the tabs differ in
+    // shape and not only in their rows.
+    expect(within(screen.getByRole('table')).getByText('committer')).toBeInTheDocument();
+    expect(within(screen.getByRole('table')).queryByText('maintainer')).not.toBeInTheDocument();
+    expect(screen.getByText('dave')).toBeInTheDocument();
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
+    expect(screen.getByText(/data as of 2026-07-26 10:00/)).toBeInTheDocument();
+    expect(screen.getByText(/whose highest role anywhere is committer/)).toBeInTheDocument();
+  });
+
+  it('keeps period tabs and role tabs distinguishable', async () => {
+    // Role tabs are not PeriodTabs: they carry no "All time" null state, and
+    // the two axes have to stay tellable apart on a table that has both.
+    await openDiversity();
+
+    expect(within(screen.getByRole('group', { name: 'Role' })).getAllByRole('button')).toHaveLength(
+      2,
+    );
+    expect(screen.queryByRole('group', { name: 'Time range' })).not.toBeInTheDocument();
+  });
+
+  it('resolves a deep link to an absorbed section, with its tab active', async () => {
+    // `#widget=committeraffiliations` predates the merge and must still land:
+    // on the card that absorbed it, scrolled to and with that tab active.
+    const scrolled: Element[] = [];
+    vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(function (this: Element) {
+      scrolled.push(this);
+    });
+    window.location.hash = 'tab=Diversity&widget=committeraffiliations';
+    render(<App />);
+
+    const card = await screen.findByText('Organisation affiliations — reference');
+    expect(card).toBeInTheDocument();
+    await screen.findByText('dave');
+    await vi.waitFor(() => expect(scrolled.map((el) => el.id)).toContain('affiliations'));
+    expect(
+      within(screen.getByRole('group', { name: 'Role' })).getByRole('button', {
+        name: 'Committers',
+      }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.queryByText('alice')).not.toBeInTheDocument();
+  });
+});
+
 describe('Per-tab explainers', () => {
   it("each tab shows its own explainer and no other tab's", async () => {
     render(<App />);

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -49,6 +49,66 @@ export const HACKERS_DOC: SectionDoc = {
   row_count: 1,
 };
 
+/**
+ * A role-tabbed table: the two tabs are disjoint populations with genuinely
+ * different shapes (the first column is labelled for the role it names), which
+ * is what the Organisation-diversity tables look like once merged.
+ */
+export const AFFILIATIONS_DOC: SectionDoc = {
+  id: 'affiliations',
+  title: 'Organisation affiliations — reference',
+  description: 'Each maintainer and the organisation they were mapped to.',
+  group: 'Organisation diversity',
+  macro: 'Diversity',
+  source: 'maintainer_affiliations.csv',
+  columns: [
+    { key: 'login', label: 'maintainer' },
+    { key: 'organisation', label: 'organisation' },
+  ],
+  rows: [
+    { login: 'alice', organisation: 'Hashgraph' },
+    { login: 'bob', organisation: 'LimeChain' },
+  ],
+  row_count: 2,
+  action: { url: 'https://example.test/affiliation', label: 'Suggest an affiliation fix' },
+  generated_at: '2026-07-25T10:00:00+00:00',
+  variants: [
+    {
+      id: 'affiliations',
+      label: 'Maintainers',
+      title: 'Maintainer affiliations — reference',
+      description: 'Each maintainer and the organisation they were mapped to.',
+      source: 'maintainer_affiliations.csv',
+      columns: [
+        { key: 'login', label: 'maintainer' },
+        { key: 'organisation', label: 'organisation' },
+      ],
+      rows: [
+        { login: 'alice', organisation: 'Hashgraph' },
+        { login: 'bob', organisation: 'LimeChain' },
+      ],
+      row_count: 2,
+      action: { url: 'https://example.test/affiliation', label: 'Suggest an affiliation fix' },
+      generated_at: '2026-07-25T10:00:00+00:00',
+    },
+    {
+      id: 'committeraffiliations',
+      label: 'Committers',
+      title: 'Committer affiliations — reference',
+      description: 'Each committer, whose highest role anywhere is committer.',
+      source: 'committer_affiliations.csv',
+      columns: [
+        { key: 'login', label: 'committer' },
+        { key: 'organisation', label: 'organisation' },
+      ],
+      rows: [{ login: 'dave', organisation: 'BlockyDevs' }],
+      row_count: 1,
+      action: { url: 'https://example.test/affiliation', label: 'Suggest an affiliation fix' },
+      generated_at: '2026-07-26T10:00:00+00:00',
+    },
+  ],
+};
+
 export const HIP_EVIDENCE_DOC: SectionDoc = {
   id: 'hip-evidence',
   title: 'Evidence (per PR)',
@@ -282,6 +342,23 @@ export const MANIFEST: Manifest = {
           row_count: 2,
           path: 'hiero-ledger/profiles.json',
         },
+        {
+          id: 'affiliations',
+          macro: 'Diversity',
+          title: 'Organisation affiliations — reference',
+          row_count: 2,
+          path: 'hiero-ledger/affiliations.json',
+        },
+        // Absorbed: still listed and still fetchable (v1 may not withdraw an
+        // id), but its rows travel inside the card above as a role tab.
+        {
+          id: 'committeraffiliations',
+          macro: 'Diversity',
+          title: 'Committer affiliations — reference',
+          row_count: 1,
+          path: 'hiero-ledger/committeraffiliations.json',
+          absorbed_by: 'affiliations',
+        },
       ],
       chart_sections: [
         {
@@ -299,6 +376,69 @@ export const MANIFEST: Manifest = {
               ],
               note: 'How to read this chart.',
               methodology: ['Step one.', 'Step two.'],
+            },
+          ],
+        },
+        // Three charts on one card: two share a Maintainers/Committers axis
+        // (so the card owns it), the third has none of its own.
+        {
+          id: 'org-diversity',
+          macro: 'Diversity',
+          title: 'Organisation diversity',
+          group: 'Organisation diversity',
+          description: 'Where write authority sits.',
+          downloads: {
+            Maintainers: {
+              name: 'maintainer_affiliations.csv',
+              path: 'hiero-ledger/maintainer_affiliations.csv',
+            },
+            Committers: {
+              name: 'committer_affiliations.csv',
+              path: 'hiero-ledger/committer_affiliations.csv',
+            },
+          },
+          charts: [
+            {
+              title: 'Role-holders by organisation',
+              variants: [
+                {
+                  label: 'Maintainers',
+                  file: 'charts/org/hiero-ledger/affiliation_donut.png',
+                  note: 'The maintainer bench by employer.',
+                  methodology: ['Count maintainers.'],
+                },
+                {
+                  label: 'Committers',
+                  file: 'charts/org/hiero-ledger/affiliation_donut_committers.png',
+                  note: 'The committer bench by employer.',
+                  methodology: ['Count committers.'],
+                },
+              ],
+              note: 'The maintainer bench by employer.',
+              methodology: ['Count maintainers.'],
+            },
+            {
+              title: 'Single-employer repos by org',
+              variants: [
+                {
+                  label: 'Maintainers',
+                  file: 'charts/org/hiero-ledger/single_employer_repos_by_org.png',
+                },
+                {
+                  label: 'Committers',
+                  file: 'charts/org/hiero-ledger/single_employer_repos_by_org_committers.png',
+                },
+              ],
+            },
+            {
+              title: 'Single-employer teams by org',
+              variants: [
+                {
+                  label: 'Single-employer teams by org',
+                  file: 'charts/org/hiero-ledger/single_employer_teams_by_org.png',
+                },
+              ],
+              note: 'Teams are membership-based, so they have no role tabs.',
             },
           ],
         },
@@ -342,7 +482,12 @@ const ROUTES: Record<string, unknown> = {
   'hiero-ledger/hip-board.json': BOARD_DOC,
   'hiero-ledger/hip-matrix.json': MATRIX_DOC,
   'hiero-ledger/profiles.json': CONTRIB_DOC,
+  'hiero-ledger/affiliations.json': AFFILIATIONS_DOC,
+  'hiero-ledger/committeraffiliations.json': AFFILIATIONS_DOC.variants?.[1],
   'hiero-hackers/profiles.json': HACKERS_DOC,
+  // Chart companion CSVs travel inside the API tree as raw text.
+  'hiero-ledger/maintainer_affiliations.csv': 'login,organisation\nalice,Hashgraph\n',
+  'hiero-ledger/committer_affiliations.csv': 'login,organisation\ndave,BlockyDevs\n',
 };
 
 /**
@@ -363,7 +508,9 @@ export function stubApi(overrides: Record<string, () => Response | Promise<Respo
       if (!match) {
         return new Response('not found', { status: 404 });
       }
-      return new Response(JSON.stringify(match[1]), { status: 200 });
+      // CSV companions are served verbatim; everything else is a JSON document.
+      const body = typeof match[1] === 'string' ? match[1] : JSON.stringify(match[1]);
+      return new Response(body, { status: 200 });
     }),
   );
 }


### PR DESCRIPTION
## Summary

Fix the five semantic and presentation regressions in the role-tabbed organisation-diversity charts and make affiliation coverage visible without widening the PNG title.

- Revert the `Unknown` donut band added in #398 at the reviewer's request; unresolved holders remain in reference/diversity tables and coverage monitoring.
- Assign organisation colours once by global seat prominence using a reviewable 20-swatch qualitative palette, with fixed greys for non-employer bands.
- Restore compact donut titles and pin both single-employer repository role variants horizontal.
- Keep vertical count annotations inside the axes, use integer value ticks, and tighten low-count annotation spacing.
- Add live Governance tiles for maintainer and committer known-affiliation shares (chosen instead of putting coverage back in the PNG title).
- Update explanatory copy and add regression tests for every reported path, including the pipeline orientation wiring.

## Defects and root causes

1. **Unwanted `Unknown` donut band:** the pipeline passed `include_unknown=True` and pinned `Unknown`, changing the pie denominator while concentration metrics still used resolved holders.
2. **Unstable or ambiguous organisation colours:** pies used slice-order defaults and compositions used role-local order; the first shared map then wrapped a seven-colour palette across 31 employers, creating real in-chart collisions.
3. **Donut forced full-row layout:** the known-share sentence appended to the title widened the exported PNG past the dashboard's `2.0` aspect threshold.
4. **Role tabs flipped bar orientation:** `plot_bar` applied its label-length heuristic independently to maintainer and committer populations.
5. **Broken small vertical count bars:** a fixed annotation offset had no matching upper-axis headroom, and the value axis had no integer locator.

## Verification

- `uv run pytest` — 749 passed, 95.49% coverage
- `uv run ruff check src tests` — passed
- `uv run hiero-analytics affiliation` — passed on the real Hiero affiliation/governance data
- `uv run hiero-analytics data_api` — emits known-affiliation tiles at 100% (maintainers) and 78% (committers)
- Real output inspection: top 10 named employers have distinct colours; Hashgraph/BlockyDevs and DSR/Hedera no longer collide; both single-employer repo variants are horizontal; donut aspects are 1.52 and 1.50

## Open follow-up questions

1. `top_n=2` makes `Other (18)` the largest committer slice and hides every named employer after Hashgraph. Should the donut retain more named employers?
2. `Unknown` remains a segment in `repo_affiliation_composition*`, which predates #398. The review objection was categorical: should those composition segments also be removed?

## Deferred scope

- The mismatch between highest-role committers in `repo_affiliation_diversity_committers.csv` and all granted committer seats in `repo_activity_overview.csv` needs a maintainer decision.
- Role-synchronised chart tabs, per-variant notes/downloads, and tabbed affiliation/diversity tables belong in the separate Organisation diversity card frontend PR.
- Curation of `?` affiliation rows and the missing All time/Active 90d variants remain separate issues.

Fixes #434

## Checklist

- [x] I claimed the linked issue with `/assign` before starting.
- [x] `uv run pytest` and `uv run ruff check src tests` pass locally.
- [x] Tests were added in paths mirroring `src/`.
- [x] Commits are signed and signed-off with `git commit -S -s`.
- [x] Documentation and dashboard copy were updated.
